### PR TITLE
Validation rule

### DIFF
--- a/src/Laravel/SocratesServiceProvider.php
+++ b/src/Laravel/SocratesServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Laravel;
 
+use Illuminate\Validation\ValidationException;
 use Reducktion\Socrates\Socrates;
 use Illuminate\Support\ServiceProvider;
 use Reducktion\Socrates\Config\Countries;
@@ -28,7 +29,9 @@ class SocratesServiceProvider extends ServiceProvider
             try {
                 return app('socrates')->validateId($value, $countryCode);
             } catch (\Exception $e) {
-                return false;
+                throw ValidationException::withMessages([
+                    $attribute => $e->getMessage()
+                ]);
             }
         }, 'National ID number is invalid.');
     }

--- a/tests/NationalIdValidationRuleTest.php
+++ b/tests/NationalIdValidationRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Reducktion\Socrates\Tests;
+
+class NationalIdValidationRuleTest extends TestCase
+{
+    /** @test */
+    public function a_valid_id_and_a_supported_country_passes():void
+    {
+        $data = [
+            'id' => '93.05.18-223.61',
+            'country' => 'BE'
+        ];
+
+        $rules = [
+            'id' => 'national_id:' . $data['country']
+        ];
+
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertTrue($validator->passes());
+    }
+
+    /** @test */
+    public function an_invalid_id_and_a_supported_country_fails():void
+    {
+        $data = [
+            'id' => '123',
+            'country' => 'BE'
+        ];
+
+        $rules = [
+            'id' => 'national_id:' . $data['country']
+        ];
+
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertTrue($validator->fails());
+    }
+}

--- a/tests/NationalIdValidationRuleTest.php
+++ b/tests/NationalIdValidationRuleTest.php
@@ -2,10 +2,12 @@
 
 namespace Reducktion\Socrates\Tests;
 
+use Illuminate\Validation\ValidationException;
+
 class NationalIdValidationRuleTest extends TestCase
 {
     /** @test */
-    public function a_valid_id_and_a_supported_country_passes():void
+    public function it_passes_if_the_user_passes_a_valid_id_and_a_supported_country(): void
     {
         $data = [
             'id' => '93.05.18-223.61',
@@ -21,7 +23,7 @@ class NationalIdValidationRuleTest extends TestCase
     }
 
     /** @test */
-    public function an_invalid_id_and_a_supported_country_fails():void
+    public function it_fails_if_the_user_passes_an_invalid_id_and_a_supported_country(): void
     {
         $data = [
             'id' => '123',
@@ -32,7 +34,26 @@ class NationalIdValidationRuleTest extends TestCase
             'id' => 'national_id:' . $data['country']
         ];
 
-        $validator = $this->app['validator']->make($data, $rules);
-        $this->assertTrue($validator->fails());
+        $this->expectException(ValidationException::class);
+        $this->app['validator']->make($data, $rules)->validate();
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_the_user_passes_an_unsupported_country(): void
+    {
+        $this->withoutExceptionHandling();
+
+        $data = [
+            'id' => '123',
+            'country' => 'BB'
+        ];
+
+        $rules = [
+            'id' => 'national_id:' . $data['country']
+        ];
+
+        $this->expectException(ValidationException::class);
+        $this->app['validator']->make($data, $rules)->validate();
+
     }
 }

--- a/tests/NationalIdValidationRuleTest.php
+++ b/tests/NationalIdValidationRuleTest.php
@@ -23,7 +23,7 @@ class NationalIdValidationRuleTest extends TestCase
     }
 
     /** @test */
-    public function it_fails_if_the_user_passes_an_invalid_id_and_a_supported_country(): void
+    public function it_throws_an_exception_if_the_user_passes_an_invalid_id_and_a_supported_country(): void
     {
         $data = [
             'id' => '123',
@@ -54,6 +54,5 @@ class NationalIdValidationRuleTest extends TestCase
 
         $this->expectException(ValidationException::class);
         $this->app['validator']->make($data, $rules)->validate();
-
     }
 }


### PR DESCRIPTION
Fixes #41.

Things added:
- The internal exception's message is now forward to the framework through a `ValidationException`
- Added new tests to verify this new behaviour