### PR TITLE
Refactor exceptions

### DIFF
--- a/src/Contracts/CitizenInformationExtractor.php
+++ b/src/Contracts/CitizenInformationExtractor.php
@@ -6,5 +6,11 @@ use Reducktion\Socrates\Models\Citizen;
 
 interface CitizenInformationExtractor
 {
+    /**
+     * Extract information from a Personal Identification Number.
+     *
+     * @param  string  $id
+     * @return Citizen
+     */
     public function extract(string $id): Citizen;
 }

--- a/src/Contracts/IdValidator.php
+++ b/src/Contracts/IdValidator.php
@@ -4,5 +4,11 @@ namespace Reducktion\Socrates\Contracts;
 
 interface IdValidator
 {
+    /**
+     * Validate a Personal Identification Number.
+     *
+     * @param  string  $id
+     * @return bool
+     */
     public function validate(string $id): bool;
 }

--- a/src/Core/Albania/AlbaniaCitizenInformationExtractor.php
+++ b/src/Core/Albania/AlbaniaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class AlbaniaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (!(new AlbaniaIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Albania/AlbaniaIdValidator.php
+++ b/src/Core/Albania/AlbaniaIdValidator.php
@@ -13,7 +13,7 @@ class AlbaniaIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10) {
-            throw new InvalidLengthException("Albanian NID must have 10 characters, got $idLength");
+            throw new InvalidLengthException('Albanian NID', '10', $idLength);
         }
 
         if (is_numeric($id[0])) {

--- a/src/Core/Belgium/BelgiumCitizenInformationExtractor.php
+++ b/src/Core/Belgium/BelgiumCitizenInformationExtractor.php
@@ -15,7 +15,7 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
         $id = $this->sanitize($id);
 
         if (! (new BelgiumIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Belgium/BelgiumIdValidator.php
+++ b/src/Core/Belgium/BelgiumIdValidator.php
@@ -38,7 +38,7 @@ class BelgiumIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11) {
-            throw new InvalidLengthException("Belgium NRN must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Belgian NRN', '11', $idLength);
         }
 
         return $id;

--- a/src/Core/BosniaAndHerzegovina/BosniaAndHerzegovinaCitizenInformationExtractor.php
+++ b/src/Core/BosniaAndHerzegovina/BosniaAndHerzegovinaCitizenInformationExtractor.php
@@ -14,13 +14,13 @@ class BosniaAndHerzegovinaCitizenInformationExtractor implements CitizenInformat
     public function extract(string $id): Citizen
     {
         if (! (new BosniaAndHerzegovinaIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Bosnian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Bosnian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/BosniaAndHerzegovina/BosniaAndHerzegovinaIdValidator.php
+++ b/src/Core/BosniaAndHerzegovina/BosniaAndHerzegovinaIdValidator.php
@@ -14,7 +14,7 @@ class BosniaAndHerzegovinaIdValidator implements IdValidator
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Bosnian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Bosnian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/Bulgaria/BulgariaCitizenInformationExtractor.php
+++ b/src/Core/Bulgaria/BulgariaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class BulgariaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new BulgariaIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Bulgaria/BulgariaIdValidator.php
+++ b/src/Core/Bulgaria/BulgariaIdValidator.php
@@ -13,7 +13,7 @@ class BulgariaIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10) {
-            throw new InvalidLengthException("The Bulgarian EGN must have 10 digits, got $idLength");
+            throw new InvalidLengthException('Bulgarian EGN', '10', $idLength);
         }
 
         $checksum = (int) substr($id, -1);

--- a/src/Core/Croatia/CroatiaCitizenInformationExtractor.php
+++ b/src/Core/Croatia/CroatiaCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class CroatiaCitizenInformationExtractor implements CitizenInformationExtractor
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Croatian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Croatian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/Croatia/CroatiaCitizenInformationExtractor.php
+++ b/src/Core/Croatia/CroatiaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class CroatiaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new CroatiaIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/Croatia/CroatiaIdValidator.php
+++ b/src/Core/Croatia/CroatiaIdValidator.php
@@ -14,19 +14,19 @@ class CroatiaIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11 && $idLength !== 13) {
-            throw new InvalidLengthException("Croatian OIB must have 11 or 13 characters, got $idLength");
+            throw new InvalidLengthException('Croatian OIB or JMBG', '11 or 13', $idLength);
         }
 
         if ($idLength === 11) {
             $checksum = (int) substr($id, -1);
-            $test = $this->calculateChecksum($id);
-            return $checksum === $test;
+            $calculatedChecksum = $this->calculateChecksum($id);
+            return $checksum === $calculatedChecksum;
         }
 
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Croatian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Croatian JMBG', '13', $idLength);
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/CzechRepublic/CzechRepublicCitizenInformationExtractor.php
+++ b/src/Core/CzechRepublic/CzechRepublicCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class CzechRepublicCitizenInformationExtractor implements CitizenInformationExtr
     public function extract(string $id): Citizen
     {
         if (! (new CzechRepublicIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/CzechRepublic/CzechRepublicCitizenInformationExtractor.php
+++ b/src/Core/CzechRepublic/CzechRepublicCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class CzechRepublicCitizenInformationExtractor implements CitizenInformationExtr
         try {
             $result = CzechoslovakiaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Czech RC must have 10 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Czech RC', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $result;

--- a/src/Core/CzechRepublic/CzechRepublicIdValidator.php
+++ b/src/Core/CzechRepublic/CzechRepublicIdValidator.php
@@ -14,7 +14,7 @@ class CzechRepublicIdValidator implements IdValidator
         try {
             $result = CzechoslovakiaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Czech RC must have 10 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Czech RC', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $result;

--- a/src/Core/Czechoslovakia/CzechoslovakiaCitizenInformationExtractor.php
+++ b/src/Core/Czechoslovakia/CzechoslovakiaCitizenInformationExtractor.php
@@ -16,7 +16,7 @@ class CzechoslovakiaCitizenInformationExtractor
         $id = str_replace('/', '', $id);
 
         if (! (new CzechoslovakiaIdValidator())::validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         $gender = self::getGender($id);

--- a/src/Core/Czechoslovakia/CzechoslovakiaCitizenInformationExtractor.php
+++ b/src/Core/Czechoslovakia/CzechoslovakiaCitizenInformationExtractor.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Core\Czechoslovakia;
 
 use Carbon\Carbon;
+use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -13,10 +14,9 @@ class CzechoslovakiaCitizenInformationExtractor
     public static function extract(string $id): Citizen
     {
         $id = str_replace('/', '', $id);
-        $idLength = strlen($id);
 
-        if ($idLength !== 10) {
-            throw new InvalidLengthException("got $idLength");
+        if (! (new CzechoslovakiaIdValidator())::validate($id)) {
+            throw new InvalidIdException('Provided ID is invalid');
         }
 
         $gender = self::getGender($id);

--- a/src/Core/Czechoslovakia/CzechoslovakiaIdValidator.php
+++ b/src/Core/Czechoslovakia/CzechoslovakiaIdValidator.php
@@ -14,7 +14,7 @@ class CzechoslovakiaIdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10) {
-            throw new InvalidLengthException("got $idLength");
+            throw new InvalidLengthException('Czechoslovakian RC', '10', $idLength);
         }
 
         $checksum = (int) substr($id, -1);

--- a/src/Core/Denmark/DenmarkCitizenInformationExtractor.php
+++ b/src/Core/Denmark/DenmarkCitizenInformationExtractor.php
@@ -15,7 +15,7 @@ class DenmarkCitizenInformationExtractor implements CitizenInformationExtractor
         $id = $this->sanitize($id);
 
         if (! (new DenmarkIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender((int) $id);

--- a/src/Core/Denmark/DenmarkIdValidator.php
+++ b/src/Core/Denmark/DenmarkIdValidator.php
@@ -38,7 +38,7 @@ class DenmarkIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10) {
-            throw new InvalidLengthException("Danish CPR must have 10 digits, got $idLength");
+            throw new InvalidLengthException('Danish CPR', '10', $idLength);
         }
 
         return $id;

--- a/src/Core/Estonia/EstoniaCitizenInformationExtractor.php
+++ b/src/Core/Estonia/EstoniaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class EstoniaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new EstoniaIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Estonia/EstoniaIdValidator.php
+++ b/src/Core/Estonia/EstoniaIdValidator.php
@@ -13,7 +13,7 @@ class EstoniaIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11) {
-            throw new InvalidLengthException("The Estonian IK must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Estonian IK', '11', $idLength);
         }
 
         $checksum = (int) substr($id, -1);

--- a/src/Core/Finland/FinlandCitizenInformationExtractor.php
+++ b/src/Core/Finland/FinlandCitizenInformationExtractor.php
@@ -15,7 +15,7 @@ class FinlandCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new FinlandIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Finland/FinlandIdValidator.php
+++ b/src/Core/Finland/FinlandIdValidator.php
@@ -11,7 +11,7 @@ class FinlandIdValidator implements IdValidator
     {
         $idLength = strlen($id);
         if ($idLength !== 11) {
-            throw new InvalidLengthException("Finnish HETU must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Finnish HETU', '11', $idLength);
         }
 
         $control = substr($id, -1);

--- a/src/Core/France/FranceCitizenInformationExtractor.php
+++ b/src/Core/France/FranceCitizenInformationExtractor.php
@@ -17,7 +17,7 @@ class FranceCitizenInformationExtractor implements CitizenInformationExtractor
         $id = $this->sanitize($id);
 
         if (! (new FranceIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/France/FranceIdValidator.php
+++ b/src/Core/France/FranceIdValidator.php
@@ -26,7 +26,7 @@ class FranceIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 15) {
-            throw new InvalidLengthException("The French INSEE must have 15 digits, got $idLength");
+            throw new InvalidLengthException('French INSEE', '15', $idLength);
         }
 
         return $id;

--- a/src/Core/Greece/GreeceIdValidator.php
+++ b/src/Core/Greece/GreeceIdValidator.php
@@ -15,7 +15,7 @@ class GreeceIdValidator implements IdValidator
         $idLength = mb_strlen($id);
 
         if ($idLength !== 8) {
-            throw new InvalidLengthException("Greek id card number must have 8 digits, got $idLength");
+            throw new InvalidLengthException('Greek id card number', '8', $idLength);
         }
 
         $greekLetters = [

--- a/src/Core/Hungary/HungaryCitizenInformationExtractor.php
+++ b/src/Core/Hungary/HungaryCitizenInformationExtractor.php
@@ -16,7 +16,7 @@ class HungaryCitizenInformationExtractor implements CitizenInformationExtractor
         $id = $this->sanitize($id);
 
         if (! (new HungaryIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $citizen = new Citizen();

--- a/src/Core/Hungary/HungaryIdValidator.php
+++ b/src/Core/Hungary/HungaryIdValidator.php
@@ -40,7 +40,7 @@ class HungaryIdValidator implements IdValidator
 
         if ($idLength !== 11) {
             throw new InvalidLengthException(
-                "The Hungarian personal identification number must have 11 digits, got $idLength"
+                'Hungarian personal identification number', '11', $idLength
             );
         }
 

--- a/src/Core/Iceland/IcelandCitizenInformationExtractor.php
+++ b/src/Core/Iceland/IcelandCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class IcelandCitizenInformationExtractor implements CitizenInformationExtractor
         $id = $this->sanitize($id);
 
         if (! (new IcelandIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $dateOfBirth = $this->getDateOfBirth($id);

--- a/src/Core/Iceland/IcelandIdValidator.php
+++ b/src/Core/Iceland/IcelandIdValidator.php
@@ -38,7 +38,7 @@ class IcelandIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10) {
-            throw new InvalidLengthException("Icelandic KR must have 10 digits, got $idLength");
+            throw new InvalidLengthException('Icelandic KR', '10',$idLength);
         }
 
         return $id;

--- a/src/Core/Ireland/IrelandIdValidator.php
+++ b/src/Core/Ireland/IrelandIdValidator.php
@@ -13,7 +13,7 @@ class IrelandIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 8 && $idLength !== 9) {
-            throw new InvalidLengthException("The Irish PPS must have 8 or 9 digits, got $idLength");
+            throw new InvalidLengthException('Irish PPS' ,'8 or 9', $idLength);
         }
 
         $sum = 0;

--- a/src/Core/Italy/ItalyCitizenInformationExtractor.php
+++ b/src/Core/Italy/ItalyCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class ItalyCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new ItalyIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $id = $this->omocodiaSwap($id);

--- a/src/Core/Italy/ItalyIdValidator.php
+++ b/src/Core/Italy/ItalyIdValidator.php
@@ -11,7 +11,7 @@ class ItalyIdValidator implements IdValidator
     {
         $idLength = strlen($id);
         if ($idLength !== 16) {
-            throw new InvalidLengthException("Italian FC must have 16 digits, got $idLength");
+            throw new InvalidLengthException('Italian FC', '16', $idLength);
         }
 
         $id = $this->omocodiaSwap($id);

--- a/src/Core/Kosovo/KosovoCitizenInformationExtractor.php
+++ b/src/Core/Kosovo/KosovoCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class KosovoCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new KosovoIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/Kosovo/KosovoCitizenInformationExtractor.php
+++ b/src/Core/Kosovo/KosovoCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class KosovoCitizenInformationExtractor implements CitizenInformationExtractor
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Kosovan JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Kosovan JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/Kosovo/KosovoIdValidator.php
+++ b/src/Core/Kosovo/KosovoIdValidator.php
@@ -14,7 +14,7 @@ class KosovoIdValidator implements IdValidator
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Kosovan JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Kosovan JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/Latvia/LatviaCitizenInformationExtractor.php
+++ b/src/Core/Latvia/LatviaCitizenInformationExtractor.php
@@ -16,7 +16,7 @@ class LatviaCitizenInformationExtractor implements CitizenInformationExtractor
         $id = $this->sanitize($id);
 
         if (! (new LatviaIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $citizen = new Citizen();

--- a/src/Core/Latvia/LatviaIdValidator.php
+++ b/src/Core/Latvia/LatviaIdValidator.php
@@ -50,7 +50,7 @@ class LatviaIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11) {
-            throw new InvalidLengthException("The Latvian PK must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Latvian PK', '11', $idLength);
         }
 
         return $id;

--- a/src/Core/Lithuania/LithuaniaCitizenInformationExtractor.php
+++ b/src/Core/Lithuania/LithuaniaCitizenInformationExtractor.php
@@ -13,7 +13,7 @@ class LithuaniaCitizenInformationExtractor implements CitizenInformationExtracto
     public function extract(string $id): Citizen
     {
         if (! (new LithuaniaIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Lithuania/LithuaniaIdValidator.php
+++ b/src/Core/Lithuania/LithuaniaIdValidator.php
@@ -11,7 +11,7 @@ class LithuaniaIdValidator implements IdValidator
     {
         $idLength = strlen($id);
         if ($idLength !== 11) {
-            throw new InvalidLengthException("Lithuanian AK must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Lithuanian AK', '11', $idLength);
         }
 
         $control = substr($id, -1);

--- a/src/Core/Luxembourg/LuxembourgCitizenInformationExtractor.php
+++ b/src/Core/Luxembourg/LuxembourgCitizenInformationExtractor.php
@@ -13,7 +13,7 @@ class LuxembourgCitizenInformationExtractor implements CitizenInformationExtract
     public function extract(string $id): Citizen
     {
         if (! (new LuxembourgIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $dob = $this->getDateOfBirth($id);

--- a/src/Core/Luxembourg/LuxembourgIdValidator.php
+++ b/src/Core/Luxembourg/LuxembourgIdValidator.php
@@ -14,7 +14,7 @@ class LuxembourgIdValidator implements IdValidator
 
         if ($idLength !== 13) {
             throw new InvalidLengthException(
-                "The Luxembourger national identification number must have 11 digits, got $idLength"
+                'Luxembourger national identification', '11', $idLength
             );
         }
 

--- a/src/Core/Moldova/MoldovaIdValidator.php
+++ b/src/Core/Moldova/MoldovaIdValidator.php
@@ -13,7 +13,7 @@ class MoldovaIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 13) {
-            throw new InvalidLengthException("Moldovan IDNP must have 13 characters, got $idLength");
+            throw new InvalidLengthException('Moldovan IDNP', '13', $idLength);
         }
 
         if (!is_numeric($id)) {

--- a/src/Core/Montenegro/MontenegroCitizenInformationExtractor.php
+++ b/src/Core/Montenegro/MontenegroCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class MontenegroCitizenInformationExtractor implements CitizenInformationExtract
     public function extract(string $id): Citizen
     {
         if (! (new MontenegroIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/Montenegro/MontenegroCitizenInformationExtractor.php
+++ b/src/Core/Montenegro/MontenegroCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class MontenegroCitizenInformationExtractor implements CitizenInformationExtract
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Montenegrin JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Montenegrin JMBG',$e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/Montenegro/MontenegroIdValidator.php
+++ b/src/Core/Montenegro/MontenegroIdValidator.php
@@ -14,7 +14,7 @@ class MontenegroIdValidator implements IdValidator
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Montenegrin JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Montenegrin JMBG',$e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/Netherlands/NetherlandsIdValidator.php
+++ b/src/Core/Netherlands/NetherlandsIdValidator.php
@@ -13,7 +13,7 @@ class NetherlandsIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 9) {
-            throw new InvalidLengthException("The Dutch BSN must have 9 digits, got $idLength");
+            throw new InvalidLengthException('Dutch BSN', '9', $idLength);
         }
 
         $lastDigit = (int) substr($id, -1);

--- a/src/Core/NorthMacedonia/NorthMacedoniaCitizenInformationExtractor.php
+++ b/src/Core/NorthMacedonia/NorthMacedoniaCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class NorthMacedoniaCitizenInformationExtractor implements CitizenInformationExt
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Macedonian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Macedonian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/NorthMacedonia/NorthMacedoniaCitizenInformationExtractor.php
+++ b/src/Core/NorthMacedonia/NorthMacedoniaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class NorthMacedoniaCitizenInformationExtractor implements CitizenInformationExt
     public function extract(string $id): Citizen
     {
         if (! (new NorthMacedoniaIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/NorthMacedonia/NorthMacedoniaIdValidator.php
+++ b/src/Core/NorthMacedonia/NorthMacedoniaIdValidator.php
@@ -14,7 +14,7 @@ class NorthMacedoniaIdValidator implements IdValidator
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Macedonian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Macedonian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/Norway/NorwayCitizenInformationExtractor.php
+++ b/src/Core/Norway/NorwayCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class NorwayCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new NorwayIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $individualNumber = (int) substr($id, 6, 3);

--- a/src/Core/Norway/NorwayIdValidator.php
+++ b/src/Core/Norway/NorwayIdValidator.php
@@ -13,7 +13,7 @@ class NorwayIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11) {
-            throw new InvalidLengthException("Norwegian fødselsnummer must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Norwegian fødselsnummer', '11', $idLength);
         }
 
         $firstControlDigit = (int) $id[9];

--- a/src/Core/Poland/PolandCitizenInformationExtractor.php
+++ b/src/Core/Poland/PolandCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class PolandCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new PolandIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Poland/PolandIdValidator.php
+++ b/src/Core/Poland/PolandIdValidator.php
@@ -13,7 +13,7 @@ class PolandIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11) {
-            throw new InvalidLengthException("The Polish PESEL must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Polish PESEL', '11', $idLength);
         }
 
         $checksum = (int) substr($id, -1);

--- a/src/Core/Portugal/PortugalIdValidator.php
+++ b/src/Core/Portugal/PortugalIdValidator.php
@@ -42,7 +42,7 @@ class PortugalIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 12) {
-            throw new InvalidLengthException("Portuguese ID Number must have 12 characters, got $idLength");
+            throw new InvalidLengthException('Portuguese ID Number', '12',$idLength);
         }
 
         return $id;

--- a/src/Core/Romania/RomaniaCitizenInformationExtractor.php
+++ b/src/Core/Romania/RomaniaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class RomaniaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new RomaniaIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id);

--- a/src/Core/Romania/RomaniaIdValidator.php
+++ b/src/Core/Romania/RomaniaIdValidator.php
@@ -11,7 +11,7 @@ class RomaniaIdValidator implements IdValidator
     {
         $idLength = strlen($id);
         if ($idLength !== 13) {
-            throw new InvalidLengthException("Romanian CNP must have 13 digits, got $idLength");
+            throw new InvalidLengthException('Romanian CNP', '13', $idLength);
         }
 
         $key = '279146358279';

--- a/src/Core/Serbia/SerbiaCitizenInformationExtractor.php
+++ b/src/Core/Serbia/SerbiaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class SerbiaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new SerbiaIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/Serbia/SerbiaCitizenInformationExtractor.php
+++ b/src/Core/Serbia/SerbiaCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class SerbiaCitizenInformationExtractor implements CitizenInformationExtractor
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Serbian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Serbian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/Serbia/SerbiaIdValidator.php
+++ b/src/Core/Serbia/SerbiaIdValidator.php
@@ -14,7 +14,7 @@ class SerbiaIdValidator implements IdValidator
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Serbian JMBG must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Serbian JMBG', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/Slovakia/SlovakiaCitizenInformationExtractor.php
+++ b/src/Core/Slovakia/SlovakiaCitizenInformationExtractor.php
@@ -15,7 +15,7 @@ class SlovakiaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new CzechRepublicIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/Slovakia/SlovakiaCitizenInformationExtractor.php
+++ b/src/Core/Slovakia/SlovakiaCitizenInformationExtractor.php
@@ -21,7 +21,7 @@ class SlovakiaCitizenInformationExtractor implements CitizenInformationExtractor
         try {
             $result = CzechoslovakiaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Slovakian RC must have 10 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Slovakian RC', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $result;

--- a/src/Core/Slovakia/SlovakiaIdValidator.php
+++ b/src/Core/Slovakia/SlovakiaIdValidator.php
@@ -14,7 +14,7 @@ class SlovakiaIdValidator implements IdValidator
         try {
             $result = CzechoslovakiaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Slovakian RC must have 10 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Slovakian RC', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $result;

--- a/src/Core/Slovenia/SloveniaCitizenInformationExtractor.php
+++ b/src/Core/Slovenia/SloveniaCitizenInformationExtractor.php
@@ -20,7 +20,7 @@ class SloveniaCitizenInformationExtractor implements CitizenInformationExtractor
         try {
             $citizen = YugoslaviaCitizenInformationExtractor::extract($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Slovenian EMSO must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Slovenian EMSO', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         return $citizen;

--- a/src/Core/Slovenia/SloveniaCitizenInformationExtractor.php
+++ b/src/Core/Slovenia/SloveniaCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class SloveniaCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new SloveniaIdValidator())->validate($id)) {
-            throw new InvalidIdException('Provided ID is invalid');
+            throw new InvalidIdException();
         }
 
         try {

--- a/src/Core/Slovenia/SloveniaIdValidator.php
+++ b/src/Core/Slovenia/SloveniaIdValidator.php
@@ -14,7 +14,7 @@ class SloveniaIdValidator implements IdValidator
         try {
             $result = YugoslaviaIdValidator::validate($id);
         } catch (InvalidLengthException $e) {
-            throw new InvalidLengthException('The Slovenian EMSO must have 13 digits, ' . $e->getMessage());
+            throw new InvalidLengthException('Slovenian EMSO', $e->getRequiredCharacters(), $e->getGivenCharacters());
         }
 
         $regionDigits = (int) substr($id, 7, 2);

--- a/src/Core/Spain/SpainIdValidator.php
+++ b/src/Core/Spain/SpainIdValidator.php
@@ -35,7 +35,7 @@ class SpainIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 9) {
-            throw new InvalidLengthException("Spanish DNI must have 9 characters, got $idLength");
+            throw new InvalidLengthException('Spanish DNI', '9', $idLength);
         }
 
         return $id;

--- a/src/Core/Sweden/SwedenCitizenInformationExtractor.php
+++ b/src/Core/Sweden/SwedenCitizenInformationExtractor.php
@@ -13,7 +13,7 @@ class SwedenCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new SwedenIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $isOverOneHundredYearsOld = $this->checkIfCitizenIsOverOneHundredYearsOld($id);

--- a/src/Core/Sweden/SwedenIdValidator.php
+++ b/src/Core/Sweden/SwedenIdValidator.php
@@ -59,7 +59,7 @@ class SwedenIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10 && $idLength !== 12) {
-            throw new InvalidLengthException("Swedish Personnummer must have 10 or 12 digits, got $idLength");
+            throw new InvalidLengthException('Swedish Personnummer', '10 or 12', $idLength);
         }
 
         return $id;

--- a/src/Core/Switzerland/SwitzerlandIdValidator.php
+++ b/src/Core/Switzerland/SwitzerlandIdValidator.php
@@ -43,7 +43,7 @@ class SwitzerlandIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 13) {
-            throw new InvalidLengthException("Swiss AVH/AVN must have 13 digits, got $idLength");
+            throw new InvalidLengthException('Swiss AVH/AVN', '13', $idLength);
         }
 
         return $id;

--- a/src/Core/Turkey/TurkeyIdValidator.php
+++ b/src/Core/Turkey/TurkeyIdValidator.php
@@ -13,7 +13,7 @@ class TurkeyIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 11) {
-            throw new InvalidLengthException("Turkish TC must have 11 digits, got $idLength");
+            throw new InvalidLengthException('Turkish TC', '11', $idLength);
         }
 
         $id = array_map(

--- a/src/Core/Ukraine/UkraineCitizenInformationExtractor.php
+++ b/src/Core/Ukraine/UkraineCitizenInformationExtractor.php
@@ -14,7 +14,7 @@ class UkraineCitizenInformationExtractor implements CitizenInformationExtractor
     public function extract(string $id): Citizen
     {
         if (! (new UkraineIdValidator())->validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = $this->getGender($id[8]);

--- a/src/Core/Ukraine/UkraineIdValidator.php
+++ b/src/Core/Ukraine/UkraineIdValidator.php
@@ -13,7 +13,7 @@ class UkraineIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 10) {
-            throw new InvalidLengthException("Ukrainian INN must have 10 digits, got $idLength");
+            throw new InvalidLengthException('Ukrainian INN', '10', $idLength);
         }
 
         if (!is_numeric($id)) {

--- a/src/Core/UnitedKingdom/UnitedKingdomIdValidator.php
+++ b/src/Core/UnitedKingdom/UnitedKingdomIdValidator.php
@@ -75,7 +75,7 @@ class UnitedKingdomIdValidator implements IdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 9) {
-            throw new InvalidLengthException("British NINO must have 9 characters, got $idLength");
+            throw new InvalidLengthException('British NINO', '9', $idLength);
         }
 
         $id = strtoupper($id);

--- a/src/Core/Yugoslavia/YugoslaviaCitizenInformationExtractor.php
+++ b/src/Core/Yugoslavia/YugoslaviaCitizenInformationExtractor.php
@@ -16,7 +16,7 @@ class YugoslaviaCitizenInformationExtractor
         $id = trim($id);
 
         if (! (new YugoslaviaIdValidator())::validate($id)) {
-            throw new InvalidIdException("Provided ID is invalid.");
+            throw new InvalidIdException();
         }
 
         $gender = self::getGender($id);

--- a/src/Core/Yugoslavia/YugoslaviaCitizenInformationExtractor.php
+++ b/src/Core/Yugoslavia/YugoslaviaCitizenInformationExtractor.php
@@ -4,6 +4,7 @@ namespace Reducktion\Socrates\Core\Yugoslavia;
 
 use Carbon\Carbon;
 use Reducktion\Socrates\Constants\Gender;
+use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Exceptions\UnrecognisedPlaceOfBirthException;
 use Reducktion\Socrates\Models\Citizen;
@@ -13,10 +14,9 @@ class YugoslaviaCitizenInformationExtractor
     public static function extract(string $id): Citizen
     {
         $id = trim($id);
-        $idLength = strlen($id);
 
-        if ($idLength !== 13) {
-            throw new InvalidLengthException("got $idLength");
+        if (! (new YugoslaviaIdValidator())::validate($id)) {
+            throw new InvalidIdException("Provided ID is invalid.");
         }
 
         $gender = self::getGender($id);

--- a/src/Core/Yugoslavia/YugoslaviaIdValidator.php
+++ b/src/Core/Yugoslavia/YugoslaviaIdValidator.php
@@ -13,7 +13,7 @@ class YugoslaviaIdValidator
         $idLength = strlen($id);
 
         if ($idLength !== 13) {
-            throw new InvalidLengthException("got $idLength");
+            throw new InvalidLengthException('Yugoslavian JMBG', '13', $idLength);
         }
 
         $checksum = (int) substr($id, -1);

--- a/src/Exceptions/InvalidIdException.php
+++ b/src/Exceptions/InvalidIdException.php
@@ -9,6 +9,6 @@ class InvalidIdException extends \LogicException
      */
     public function __construct()
     {
-        parent::__construct('The National ID provided is invalid.');
+        parent::__construct('The provided National ID is invalid.');
     }
 }

--- a/src/Exceptions/InvalidIdException.php
+++ b/src/Exceptions/InvalidIdException.php
@@ -4,4 +4,11 @@ namespace Reducktion\Socrates\Exceptions;
 
 class InvalidIdException extends \LogicException
 {
+    /**
+     * InvalidIdException constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct('The National ID provided is invalid.');
+    }
 }

--- a/src/Exceptions/InvalidLengthException.php
+++ b/src/Exceptions/InvalidLengthException.php
@@ -4,34 +4,49 @@ namespace Reducktion\Socrates\Exceptions;
 
 class InvalidLengthException extends \LogicException
 {
-    public $designation;
-    public $requiredCharacters;
-    public $givenCharacters;
+    /**
+     * The name of the National Identification Number.
+     *
+     * @var string
+     */
+    private $designation;
 
     /**
-     * InvalidLengthException constructor.
+     * Description of the number of characters the National Identification Number should have.
      *
-     * @param $designation
-     * @param $requiredCharacters
-     * @param $givenCharacters
+     * @var string
+     */
+    private $requiredCharacters;
+
+    /**
+     * Description of the numbers of characters that were passed.
+     *
+     * @var string
+     */
+    private $givenCharacters;
+
+    /**
+     * Create a new InvalidLengthException instance.
+     *
+     * @param  string  $designation
+     * @param  string  $requiredCharacters
+     * @param  string  $givenCharacters
+     * @return void
      */
     public function __construct(string $designation, string $requiredCharacters, string $givenCharacters)
     {
         $this->designation = $designation;
+
         $this->requiredCharacters = $requiredCharacters;
+
         $this->givenCharacters = $givenCharacters;
+
         parent::__construct("The $designation must have $requiredCharacters characters, but got $givenCharacters.");
     }
 
     /**
-     * @return string
-     */
-    public function getDesignation(): string
-    {
-        return $this->designation;
-    }
-
-    /**
+     * Get the required characters.
+     *
      * @return string
      */
     public function getRequiredCharacters(): string
@@ -40,6 +55,8 @@ class InvalidLengthException extends \LogicException
     }
 
     /**
+     * Get given characters.
+     *
      * @return string
      */
     public function getGivenCharacters(): string

--- a/src/Exceptions/InvalidLengthException.php
+++ b/src/Exceptions/InvalidLengthException.php
@@ -4,4 +4,46 @@ namespace Reducktion\Socrates\Exceptions;
 
 class InvalidLengthException extends \LogicException
 {
+    public $designation;
+    public $requiredCharacters;
+    public $givenCharacters;
+
+    /**
+     * InvalidLengthException constructor.
+     *
+     * @param $designation
+     * @param $requiredCharacters
+     * @param $givenCharacters
+     */
+    public function __construct(string $designation, string $requiredCharacters, string $givenCharacters)
+    {
+        $this->designation = $designation;
+        $this->requiredCharacters = $requiredCharacters;
+        $this->givenCharacters = $givenCharacters;
+        parent::__construct("The $designation must have $requiredCharacters characters, but got $givenCharacters.");
+    }
+
+    /**
+     * @return string
+     */
+    public function getDesignation(): string
+    {
+        return $this->designation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequiredCharacters(): string
+    {
+        return $this->requiredCharacters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGivenCharacters(): string
+    {
+        return $this->givenCharacters;
+    }
 }

--- a/src/Models/Citizen.php
+++ b/src/Models/Citizen.php
@@ -7,20 +7,52 @@ use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
 
 class Citizen
 {
+    /**
+     * The gender as a string.
+     *
+     * @var string|null
+     */
     private $gender;
+
+    /**
+     * The date of birth as a Carbon instance.
+     *
+     * @var Carbon|null
+     */
     private $dateOfBirth;
+
+    /**
+     * The place of birth as a string.
+     *
+     * @var string|null
+     */
     private $placeOfBirth;
 
+    /**
+     * Get the gender.
+     *
+     * @return  string|null
+     */
     public function getGender(): ?string
     {
         return $this->gender;
     }
 
+    /**
+     * Get the date of birth.
+     *
+     * @return Carbon|null
+     */
     public function getDateOfBirth(): ?Carbon
     {
         return $this->dateOfBirth;
     }
 
+    /**
+     * Get the age.
+     *
+     * @return int|null
+     */
     public function getAge(): ?int
     {
         if (!$this->dateOfBirth) {
@@ -30,22 +62,45 @@ class Citizen
         return $this->dateOfBirth->age;
     }
 
+    /**
+     * Get the place of birth.
+     *
+     * @return string|null
+     */
     public function getPlaceOfBirth(): ?string
     {
         return $this->placeOfBirth;
     }
 
-    public function setGender($gender): void
+    /**
+     * Set the gender.
+     *
+     * @param  string  $gender
+     * @return void
+     */
+    public function setGender(string $gender): void
     {
         $this->gender = $gender;
     }
 
+    /**
+     * Set the date of birth.
+     *
+     * @param  Carbon  $dateOfBirth
+     * @return  void
+     */
     public function setDateOfBirth(Carbon $dateOfBirth): void
     {
         $this->dateOfBirth = $dateOfBirth;
     }
 
-    public function setPlaceOfBirth($placeOfBirth): void
+    /**
+     * Set the place of birth.
+     *
+     * @param  string  $placeOfBirth
+     * @return void
+     */
+    public function setPlaceOfBirth(string $placeOfBirth): void
     {
         $this->placeOfBirth = $placeOfBirth;
     }

--- a/src/Socrates.php
+++ b/src/Socrates.php
@@ -3,6 +3,9 @@
 namespace Reducktion\Socrates;
 
 use Locale;
+use Reducktion\Socrates\Exceptions\InvalidIdException;
+use Reducktion\Socrates\Exceptions\InvalidLengthException;
+use Reducktion\Socrates\Exceptions\UnrecognisedPlaceOfBirthException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Config\Countries;
 use Reducktion\Socrates\Core\IdValidatorFactory;
@@ -19,8 +22,11 @@ class Socrates
      *
      * @param  string  $id
      * @param  string  $countryCode
-     *
-     * @return \Reducktion\Socrates\Models\Citizen
+     * @return Citizen
+     * @throws InvalidIdException if the provided National Identification Number is invalid.
+     * @throws UnrecognisedPlaceOfBirthException if the encoded place of birth is wrong or invalid.
+     * @throws UnsupportedOperationException if the version or format of the National Identification Number does
+     * not support a given operation.
      */
     public function getCitizenDataFromId(string $id, string $countryCode = ''): Citizen
     {
@@ -40,8 +46,8 @@ class Socrates
      *
      * @param  string  $id
      * @param  string  $countryCode
-     *
      * @return bool
+     * @throws InvalidLengthException if the provided National Identification Number has the wrong length.
      */
     public function validateId(string $id, string $countryCode = ''): bool
     {
@@ -58,8 +64,9 @@ class Socrates
      * Transforms the provided country code to the ISO 3166-2 format.
      *
      * @param  string  $countryCode
-     *
      * @return string
+     * @throws InvalidCountryCodeException if the provided country code is not provided or is not in the right format.
+     * @throws UnrecognisedCountryException if the provided country code does not correspond to any country.
      */
     private function formatCountryCode(string $countryCode): string
     {
@@ -96,6 +103,9 @@ class Socrates
      * Verifies if a given country supports Citizen data extraction.
      *
      * @param  string  $countryCode
+     * @return void
+     * @throws UnsupportedOperationException if the provided country does not supported extracting data from
+     * the Personal Identification Number.
      */
     private function checkIfCountrySupportsCitizenData(string $countryCode): void
     {

--- a/tests/Feature/CroatiaTest.php
+++ b/tests/Feature/CroatiaTest.php
@@ -89,8 +89,6 @@ class CroatiaTest extends FeatureTest
             Socrates::getCitizenDataFromId($person, 'HR');
         }
 
-        $this->expectException(InvalidLengthException::class);
-
         Socrates::getCitizenDataFromId('1821992971', 'HR');
     }
 


### PR DESCRIPTION
Fixes #42.

Things changed:
- `InvalidLengthException` now receives the information needed to create an error message, and constructs the message equally for every country
- `InvalidIdException` doesn't have any parameter and the error message is built identically for every country