### PR TITLE
Correct Portugal validation algorithm

### DIFF
--- a/src/Core/Portugal/PortugalIdValidator.php
+++ b/src/Core/Portugal/PortugalIdValidator.php
@@ -24,10 +24,10 @@ class PortugalIdValidator implements IdValidator
                 if ($value > 9) {
                     $value -= 9;
                 }
-
-                $sum += $value;
-                $toggleDigit = !$toggleDigit;
             }
+
+            $sum += $value;
+            $toggleDigit = !$toggleDigit;
         }
 
         return ($sum % 10) === 0;

--- a/tests/Feature/PortugalTest.php
+++ b/tests/Feature/PortugalTest.php
@@ -9,6 +9,7 @@ use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
 class PortugalTest extends FeatureTest
 {
     private $validIds;
+    private $invalidIds;
 
     protected function setUp(): void
     {
@@ -20,6 +21,14 @@ class PortugalTest extends FeatureTest
             '17653917 4ZZ5',
             '174886721 ZX1',
             '14898475 4 ZY5',
+        ];
+
+        $this->invalidIds = [
+            '11084129 0 ZX8',
+            '154A03556ZX9',
+            '176CD917 4ZZ5',
+            '174886000 ZX1',
+            '14811175 4 ZY5',
         ];
     }
 
@@ -38,12 +47,14 @@ class PortugalTest extends FeatureTest
             );
         }
 
+        foreach ($this->invalidIds as $invalidId) {
+            $this->assertFalse(
+                Socrates::validateId($invalidId, 'PT')
+            );
+        }
+
         $this->expectException(InvalidLengthException::class);
 
         Socrates::validateId('11084129 8 ZX', 'PT');
-
-        $this->assertFalse(
-            Socrates::validateId('14897475 4 ZY5', 'PT')
-        );
     }
 }


### PR DESCRIPTION
The Portugal validation algorithm has a bug in an if code block that is never run. In 
```PHP
public function validate(string $id): bool
    {
        $id = $this->sanitize($id);

        $sum = 0;
        $toggleDigit = false;

        for ($i = 11; $i >= 0; $i--) {
            $value = $this->getCharacterValue($id[$i]);

            if ($toggleDigit) {
                $value *= 2;

                if ($value > 9) {
                    $value -= 9;
                }

                $sum += $value;
                $toggleDigit = !$toggleDigit;
            }
        }

        return ($sum % 10) === 0;
    }
```
the `$toggleDigit` is initialized to false and is not modified outside of the if statement, which depends on it being true to run.