### PR TITLE
Add special month codes to the french ID Validator

### DIFF
--- a/src/Core/France/FranceCitizenInformationExtractor.php
+++ b/src/Core/France/FranceCitizenInformationExtractor.php
@@ -47,9 +47,9 @@ class FranceCitizenInformationExtractor implements CitizenInformationExtractor
     {
         $dateDigits = substr($id, 1, 4);
         [$year, $month] = str_split($dateDigits, 2);
-        $currentYear = (int) now()->format('y');
+        $currentYear = now()->format('y');
 
-        $year = (int) $year > $currentYear ? (int) $year + 1900 : (int) $year + 2000;
+        $year = $year > $currentYear ? $year + 1900 : $year + 2000;
 
         if ($month > 0 && $month < 13) {
             return Carbon::createFromFormat('Y-m', "$year-$month");

--- a/src/Core/France/FranceCitizenInformationExtractor.php
+++ b/src/Core/France/FranceCitizenInformationExtractor.php
@@ -51,7 +51,16 @@ class FranceCitizenInformationExtractor implements CitizenInformationExtractor
 
         $year = (int) $year > $currentYear ? (int) $year + 1900 : (int) $year + 2000;
 
-        return Carbon::createFromFormat('Y-m', "$year-$month");
+        if ($month > 0 && $month < 13) {
+            return Carbon::createFromFormat('Y-m', "$year-$month");
+        }
+
+        if ($month > 30 && $month < 43) {
+            $month -= 30;
+            return Carbon::createFromFormat('Y-m', "$year-$month");
+        }
+
+        return Carbon::createFromFormat('Y', $year);
     }
 
     private function getPlaceOfBirth(string $id): string

--- a/tests/Feature/FranceTest.php
+++ b/tests/Feature/FranceTest.php
@@ -65,6 +65,20 @@ class FranceTest extends FeatureTest
                 'dob' => Carbon::createFromFormat('Y-m', '2004-10'),
                 'age' => Carbon::createFromFormat('Y-m', '2004-10')->age,
                 'pob' => 'French Polynesia'
+            ],
+            'Leal' => [
+                'insee' => '1103442505781 11',
+                'gender' => Gender::MALE,
+                'dob' => Carbon::createFromFormat('Y-m', '2010-04'),
+                'age' => Carbon::createFromFormat('Y-m', '2010-04')->age,
+                'pob' => 'Loire'
+            ],
+            'Odelette' => [
+                'insee' => '2115028242370 20',
+                'gender' => Gender::FEMALE,
+                'dob' => Carbon::createFromFormat('Y', '2011'),
+                'age' => Carbon::createFromFormat('Y', '2011')->age,
+                'pob' => 'Eure-et-Loir'
             ]
         ];
 


### PR DESCRIPTION
This PR fixes #61.

As said by @SLourenco (please feel free to give feedback), the French ID (INSEE) allow more options related to the month code than what was implemented at the start.

The following cases were added:

- When the month is unknown, only the year is extracted.
- When the month code belongs to a person with an incomplete civil status, the month and the year are extracted (applying the required conversion).