### PR TITLE
Fix Validation tests

### DIFF
--- a/src/Core/Spain/SpainIdValidator.php
+++ b/src/Core/Spain/SpainIdValidator.php
@@ -30,14 +30,14 @@ class SpainIdValidator implements IdValidator
     {
         $id = strtoupper($id);
 
-        $id = str_replace('-', '', $id);
+        $idArray = str_replace('-', '', $id);
 
-        $idLength = strlen($id);
+        $idLength = strlen($idArray);
 
         if ($idLength !== 9) {
             throw new InvalidLengthException('Spanish DNI', '9', $idLength);
         }
 
-        return $id;
+        return $idArray;
     }
 }

--- a/tests/Feature/BelgiumTest.php
+++ b/tests/Feature/BelgiumTest.php
@@ -86,5 +86,9 @@ class BelgiumTest extends FeatureTest
                 Socrates::validateId($id, 'BE')
             );
         }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::getCitizenDataFromId('12.12.12-1323.32', 'BE');
     }
 }

--- a/tests/Feature/GreeceTest.php
+++ b/tests/Feature/GreeceTest.php
@@ -25,7 +25,7 @@ class GreeceTest extends FeatureTest
         ];
 
         $this->invalidIds = [
-            'ΔΞ-89172',
+            'Δx-091003',
             'Ω-1213312',
             'ΒΖΜ-98912',
             'ΧΘ-543971',
@@ -50,14 +50,14 @@ class GreeceTest extends FeatureTest
             );
         }
 
-        $this->expectException(InvalidLengthException::class);
-
-        Socrates::validateId('ΔΞ-89172', 'GR');
-
         foreach ($this->invalidIds as $invalidId) {
             $this->assertFalse(
                 Socrates::validateId($invalidId, 'GR')
             );
         }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::validateId('ΔΞ-89172', 'GR');
     }
 }

--- a/tests/Feature/IrelandTest.php
+++ b/tests/Feature/IrelandTest.php
@@ -47,15 +47,14 @@ class IrelandTest extends FeatureTest
             );
         }
 
-        $this->expectException(InvalidLengthException::class);
-
-        Socrates::validateId('648295R', 'IE');
-
-
         foreach ($this->invalidIds as $id) {
             $this->assertFalse(
                 Socrates::validateId($id, 'IE')
             );
         }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::validateId('648295R', 'IE');
     }
 }

--- a/tests/Feature/MoldovaTest.php
+++ b/tests/Feature/MoldovaTest.php
@@ -45,15 +45,14 @@ class MoldovaTest extends FeatureTest
             );
         }
 
-        $this->expectException(InvalidLengthException::class);
-
-        Socrates::validateId('648295', 'MD');
-
-
         foreach ($this->invalidIds as $id) {
             $this->assertFalse(
                 Socrates::validateId($id, 'MD')
             );
         }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::validateId('648295', 'MD');
     }
 }

--- a/tests/Feature/NetherlandsTest.php
+++ b/tests/Feature/NetherlandsTest.php
@@ -26,7 +26,7 @@ class NetherlandsTest extends FeatureTest
         $this->invalidIds = [
             '692676411',
             '918271871',
-            '998786123',
+            '908786123',
             '123128764',
             '817187288',
         ];
@@ -47,15 +47,14 @@ class NetherlandsTest extends FeatureTest
             );
         }
 
-        $this->expectException(InvalidLengthException::class);
-
-        Socrates::validateId('692676', 'NL');
-
-
         foreach ($this->invalidIds as $id) {
             $this->assertFalse(
                 Socrates::validateId($id, 'NL')
             );
         }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::validateId('692676', 'NL');
     }
 }

--- a/tests/Feature/SpainTest.php
+++ b/tests/Feature/SpainTest.php
@@ -9,6 +9,7 @@ use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
 class SpainTest extends FeatureTest
 {
     private $validIds;
+    private $invalidIds;
 
     protected function setUp(): void
     {
@@ -20,6 +21,14 @@ class SpainTest extends FeatureTest
             '40298386V',
             'Y0597591L',
             '09730915Y',
+        ];
+
+        $this->invalidIds = [
+            '05756786M',
+            'YY597522L',
+            '4020X069V',
+            'XX-597591L',
+            '09730215Y',
         ];
     }
 
@@ -38,12 +47,14 @@ class SpainTest extends FeatureTest
             );
         }
 
+        foreach ($this->invalidIds as $invalidId) {
+            $this->assertFalse(
+                Socrates::validateId($invalidId, 'ES')
+            );
+        }
+
         $this->expectException(InvalidLengthException::class);
 
         Socrates::validateId('05751086', 'ES');
-
-        $this->assertFalse(
-            Socrates::validateId('05756786M', 'ES')
-        );
     }
 }

--- a/tests/Feature/SwitzerlandTest.php
+++ b/tests/Feature/SwitzerlandTest.php
@@ -9,6 +9,7 @@ use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
 class SwitzerlandTest extends FeatureTest
 {
     private $validIds;
+    private $invalidIds;
 
     protected function setUp(): void
     {
@@ -20,6 +21,14 @@ class SwitzerlandTest extends FeatureTest
             '756.6608.0959.83',
             '7562514028206',
             '7568193378885',
+        ];
+
+        $this->invalidIds = [
+            '7668193378885',
+            '046.6620.1959.12',
+            '776.6608.0959.83',
+            '75.62000008206',
+            '7568.193378002',
         ];
     }
 
@@ -38,6 +47,12 @@ class SwitzerlandTest extends FeatureTest
             );
         }
 
+        foreach ($this->invalidIds as $invalidId) {
+            $this->assertFalse(
+                Socrates::validateId($invalidId, 'CH')
+            );
+        }
+
         $this->expectException(InvalidLengthException::class);
 
         Socrates::validateId('756.608.0959.83', 'CH');
@@ -45,13 +60,5 @@ class SwitzerlandTest extends FeatureTest
         $this->expectException(InvalidLengthException::class);
 
         Socrates::validateId('756193378885', 'CH');
-
-        $this->assertFalse(
-            Socrates::validateId('7668193378885', 'CH')
-        );
-
-        $this->assertFalse(
-            Socrates::validateId('046.6620.1959.12', 'CH')
-        );
     }
 }

--- a/tests/Feature/TurkeyTest.php
+++ b/tests/Feature/TurkeyTest.php
@@ -9,6 +9,7 @@ use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
 class TurkeyTest extends FeatureTest
 {
     private $validIds;
+    private $invalidIds;
 
     protected function setUp(): void
     {
@@ -20,6 +21,14 @@ class TurkeyTest extends FeatureTest
             '16215434196',
             '20329122900',
             '61614559018',
+        ];
+
+        $this->invalidIds = [
+            '16675430196',
+            '06675430196',
+            '16200000196',
+            '20333322900',
+            '63424559018',
         ];
     }
 
@@ -38,16 +47,14 @@ class TurkeyTest extends FeatureTest
             );
         }
 
+        foreach ($this->invalidIds as $invalidId) {
+            $this->assertFalse(
+                Socrates::validateId($invalidId, 'TR')
+            );
+        }
+
         $this->expectException(InvalidLengthException::class);
 
         Socrates::validateId('1621543419643', 'TR');
-
-        $this->assertFalse(
-            Socrates::validateId('16675430196', 'TR')
-        );
-
-        $this->assertFalse(
-            Socrates::validateId('06675430196', 'TR')
-        );
     }
 }

--- a/tests/Feature/UnitedKingdomTest.php
+++ b/tests/Feature/UnitedKingdomTest.php
@@ -28,9 +28,9 @@ class UnitedKingdomTest extends FeatureTest
 
         $this->invalidIds = [
             'AA 37 07 73 F',
-            '3392 2870',
+            '3392 2870 9',
             'GG 79 gj 59 B',
-            'FO 99 04 28',
+            'FO 99 04 28 C',
             'GB 79 89 59 B',
             'NK 79 89 59 B',
             'TN 79 89 59 B',
@@ -56,14 +56,14 @@ class UnitedKingdomTest extends FeatureTest
             );
         }
 
-        $this->expectException(InvalidLengthException::class);
-
-        Socrates::validateId('AA370773', 'GB');
-
         foreach ($this->invalidIds as $invalidId) {
             $this->assertFalse(
                 Socrates::validateId($invalidId, 'GB')
             );
         }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::validateId('AA370773', 'GB');
     }
 }


### PR DESCRIPTION
This will close #59 

Some validation tests were still asserting the length exception was thrown _before_ checking for invalid IDs.

This PR fixes those instances, as well as adding some more invalid IDs to check where needed.