### PR TITLE
Added Brazil ID (CPF) checker

### DIFF
--- a/COUNTRIES.md
+++ b/COUNTRIES.md
@@ -6,6 +6,7 @@
 | Belgium 🇧🇪                |      BE      | :heavy_check_mark: | :heavy_check_mark: |
 | Bosnia and Herzegovina 🇧🇦 |      BA      | :heavy_check_mark: | :heavy_check_mark: |
 | Bulgaria 🇧🇬               |      BG      | :heavy_check_mark: | :heavy_check_mark: |
+| Brazil 🇧🇷                 |      BR      | :heavy_check_mark: | :x:                |
 | Croatia 🇭🇷                |      HR      | :heavy_check_mark: | :heavy_check_mark: |
 | Czech Republic 🇨🇿         |      CZ      | :heavy_check_mark: | :heavy_check_mark: |
 | Denmark 🇩🇰                |      DK      | :heavy_check_mark: | :heavy_check_mark: |

--- a/src/Config/Countries.php
+++ b/src/Config/Countries.php
@@ -262,6 +262,7 @@ class Countries
         'BA' => \Reducktion\Socrates\Core\BosniaAndHerzegovina\BosniaAndHerzegovinaIdValidator::class,
         'BE' => \Reducktion\Socrates\Core\Belgium\BelgiumIdValidator::class,
         'BG' => \Reducktion\Socrates\Core\Bulgaria\BulgariaIdValidator::class,
+        'BR' => \Reducktion\Socrates\Core\Brazil\BrazilIdValidator::class,
         'CH' => \Reducktion\Socrates\Core\Switzerland\SwitzerlandIdValidator::class,
         'CZ' => \Reducktion\Socrates\Core\CzechRepublic\CzechRepublicIdValidator::class,
         'DK' => \Reducktion\Socrates\Core\Denmark\DenmarkIdValidator::class,

--- a/src/Core/Brazil/BrazilIdValidator.php
+++ b/src/Core/Brazil/BrazilIdValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Reducktion\Socrates\Core\Brazil;
+
+use Reducktion\Socrates\Contracts\IdValidator;
+use Reducktion\Socrates\Exceptions\InvalidLengthException;
+
+class BrazilIdValidator implements IdValidator
+{
+    public function validate(string $id): bool
+    {
+        $id = $this->sanitize($id);
+
+        $checksum = (int) substr($id, -2);
+        $id = substr($id, 0, -2);
+
+        $cpfArray = array_reverse(
+            array_map(
+                static function ($digit) {
+                    return (int) $digit;
+                },
+                str_split($id)
+            )
+        );
+
+        // source: https://pt.wikipedia.org/wiki/Cadastro_de_pessoas_f%C3%ADsicas#Algoritmo
+        $v1 = 0;
+        $v2 = 0;
+        for ($i = 0; $i < 9; $i++) {
+            $v1 = $v1 + $cpfArray[$i] * (9 - ($i % 10));
+            $v2 = $v2 + $cpfArray[$i] * (9 - (($i + 1) % 10));
+        }
+
+        $v1 = ($v1 % 11) % 10;
+        $v2 = $v2 + ($v1 * 9);
+        $v2 = ($v2 % 11) % 10;
+
+        return $checksum === (($v1 * 10) + $v2);
+    }
+
+    private function sanitize(string $id): string
+    {
+        $id = preg_replace('/[^0-9]/', '', $id);
+
+        $idLength = strlen($id);
+
+        if ($idLength !== 11) {
+            throw new InvalidLengthException('Brazil CPF', '11', $idLength);
+        }
+
+        return $id;
+    }
+}

--- a/tests/Feature/BrazilTest.php
+++ b/tests/Feature/BrazilTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Reducktion\Socrates\Tests\Feature;
+
+use Reducktion\Socrates\Laravel\Facades\Socrates;
+use Reducktion\Socrates\Exceptions\InvalidLengthException;
+use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
+
+class BrazilTest extends FeatureTest
+{
+    private $validIds;
+    private $invalidIds;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // one per state
+        $this->validIds = [
+            '14441676263',
+            '62363568400',
+            '92205820230',
+            '88958056231',
+            '90701066555',
+            '31098035348',
+            '54271183148',
+            '03860881795',
+            '15777379117',
+            '46959616360',
+            '51861041675',
+            '35823686102',
+            '26319324120',
+            '81036850463',
+            '17188856443',
+            '16556182451',
+            '13369586347',
+            '19319810940',
+            '41120495792',
+            '79950524482',
+            '44667914068',
+            '41947527240',
+            '23554835234',
+            '04008125922',
+            '37025634581',
+            '26363102820',
+            '17758534112',
+        ];
+
+        $this->invalidIds = [
+            '23294954040',
+            '92940752020',
+            '34612661005',
+            '46943217073',
+            '13109540000',
+        ];
+    }
+
+    public function test_extract_behaviour(): void
+    {
+        $this->expectException(UnsupportedOperationException::class);
+
+        Socrates::getCitizenDataFromId('', 'BR');
+    }
+
+    public function test_validation_behaviour(): void
+    {
+        foreach ($this->validIds as $id) {
+            $this->assertTrue(
+                Socrates::validateId($id, 'BR'),
+                $id
+            );
+        }
+
+        foreach ($this->invalidIds as $id) {
+            $this->assertFalse(
+                Socrates::validateId($id, 'BR')
+            );
+        }
+
+        $this->expectException(InvalidLengthException::class);
+
+        Socrates::validateId('648295', 'BR');
+    }
+}


### PR DESCRIPTION
This PR adds Brazil ID (CPF) checker based on the algorithm available on [Wikipedia](https://pt.wikipedia.org/wiki/Cadastro_de_pessoas_f%C3%ADsicas#Algoritmo).