### PR TITLE
Fix ID validation Belgium.

### DIFF
--- a/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
+++ b/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
@@ -37,7 +37,7 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
 
     private function sanitize(string $id): string
     {
-        $id = str_replace(['-', '.'], '', $id);
+        $id = str_replace(['-', ' ', '.'], '', $id);
 
         return $id;
     }
@@ -51,6 +51,10 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
     {
         $dateDigits = substr($id, 0, 6);
         [$year, $month, $day] = str_split($dateDigits, 2);
+
+        // use first day or month if unknown
+        $month = $month == 0 ? 1 : $month;
+        $day = $day == 0 ? 1 : $day;
 
         $year = $this->isAfter2000($id) ? $year + 2000 : $year + 1900;
 

--- a/tests/Feature/Europe/BelgiumTest.php
+++ b/tests/Feature/Europe/BelgiumTest.php
@@ -49,6 +49,18 @@ class BelgiumTest extends FeatureTest
                 'dob' => Carbon::createFromFormat('Y-m-d', '1971-09-07'),
                 'age' => Carbon::createFromFormat('Y-m-d', '1971-09-07')->age,
             ],
+            'john' => [
+                'id' => '40 00 00-953 81',
+                'gender' => Gender::MALE,
+                'dob' => Carbon::createFromFormat('Y-m-d', '1940-01-01'),
+                'age' => Carbon::createFromFormat('Y-m-d', '1940-01-01')->age,
+            ],
+            'mark' => [
+                'id' => '40.00.01-001.33',
+                'gender' => Gender::MALE,
+                'dob' => Carbon::createFromFormat('Y-m-d', '1940-01-01'),
+                'age' => Carbon::createFromFormat('Y-m-d', '1940-01-01')->age,
+            ]
         ];
 
         $this->invalidIds = [
@@ -56,7 +68,9 @@ class BelgiumTest extends FeatureTest
             '97.12.03-123.12',
             '01.06.18-468.99',
             '64.04.09-874.43',
-            '12.10.23-954.11'
+            '12.10.23-954.11',
+            '01.11.16-000.06', // invalid sequence number
+            '01.11.16-999.74'  // invalid sequence number
         ];
     }
 


### PR DESCRIPTION
Fixes #82  .

Changes:

- added sequence number validation (valid range is 001 - 998)
- 00 as day or 00 as month is now also valid
- allow for spaces in ID number

Included additional tests to test the changes.