### PR TITLE
Add native DateTime support and deprecate the old getDateOfBirth method

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        php-version: '7.2'
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        php-version: '7.2'
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -34,7 +32,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --no-progress --no-suggest
 
     - name: Run test suite
       run: vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,27 +12,39 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        php-versions: ['7.2', '7.3', '7.4']
+    runs-on: ${{ matrix.operating-system }}
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl
+          ini-values: post_max_size=256M, log_errors=1
+          coverage: pcov
+          tools: pecl
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
       
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-node-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-node-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --no-progress --no-suggest
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
 
-    - name: Run test suite
-      run: vendor/bin/phpunit
+      - name: Run test suite
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ This method will return an instance of `Citizen`. If the ID is invalid, an `Inva
 $citizen = $socrates->getCitizenDataFromId('3860123012', Country::ESTONIA);
 ```
 
-The `Citizen` class stores the extracted citizen data in a consistent format across all countries. It exposes the `getGender()`, `getDateOfBirth()`, `getAge()` and `getPlaceOfBirth()` methods.
-All will return a `string` (for the gender and place of birth), `int`(for age), a `Carbon` instance (for the date of birth) or `null` if the value is empty.
+The `Citizen` class stores the extracted citizen data in a consistent format across all countries.<br>
+It exposes the `getGender()`, `getDateOfBirthNative()`, `getDateOfBirth()`, `getAge()` and `getPlaceOfBirth()` methods.<br><br>
+Both `getGender` and `getPlaceOfBirth` return a `string`, `getAge()` returns an `int`, `getDateOfBirthNative()` returns a native `DateTime` and `getDateOfBirth()` returns a `Carbon` instance. <br>
+**It is recommended to use `getDateOfBirthNative()` as Carbon will be removed as a dependency in a future release of Socrates.**
 <p>Using the example above, Estonia only encodes the date of birth and gender of the citizen in their ID. So the above methods will return:</p>
  
 ```php
 echo $citizen->getGender(); // 'Male'
-echo $citizen->getDateOfBirth(); // A Carbon instance with the date '1986-01-23'
+echo $citizen->getDateOfBirthNative(); // DateTime instance with the date '1986-01-23'
+echo $citizen->getDateOfBirth(); // DEPRECATED - Carbon instance with the date '1986-01-23'
 echo $citizen->getAge(); // 34 (as of June 2020)
 echo $citizen->getPlaceOfBirth(); // null
 ```

--- a/src/Core/Europe/Albania/AlbaniaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Albania/AlbaniaCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Albania;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Constants\Gender;
@@ -41,7 +41,7 @@ class AlbaniaCitizenInformationExtractor implements CitizenInformationExtractor
         return Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$yearCode, $monthDigits, $day] = str_split($dateDigits, 2);
@@ -52,7 +52,7 @@ class AlbaniaCitizenInformationExtractor implements CitizenInformationExtractor
 
         $month = $this->getMonthFromDigits($monthDigits, $this->getGender($id));
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 
     private function getYearFromCode(string $yearCode): int

--- a/src/Core/Europe/Albania/AlbaniaIdValidator.php
+++ b/src/Core/Europe/Albania/AlbaniaIdValidator.php
@@ -20,7 +20,7 @@ class AlbaniaIdValidator implements IdValidator
         }
 
         $id = strtoupper($id);
-        $id = str_split($id);
+        $idArray = str_split($id);
 
         $verificationTable = [
             1 => 'A',
@@ -48,11 +48,11 @@ class AlbaniaIdValidator implements IdValidator
             0 => 'W',
         ];
 
-        $firstLetter = $id[0];
-        $checkLetter = $id[9];
-        $firstLetterNumber = array_search($firstLetter, $verificationTable);
+        $firstLetter = $idArray[0];
+        $checkLetter = $idArray[9];
+        $firstLetterNumber = array_search($firstLetter, $verificationTable, true);
 
-        $eightMiddleDigits = array_slice($id, 1, 8);
+        $eightMiddleDigits = array_slice($idArray, 1, 8);
 
         $sum = array_sum(
             array_map(

--- a/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
+++ b/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Belgium;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -47,7 +47,7 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
         return (substr($id, 6, 3) % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$year, $month, $day] = str_split($dateDigits, 2);
@@ -58,7 +58,7 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
 
         $year = $this->isAfter2000($id) ? $year + 2000 : $year + 1900;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 
     private function isAfter2000($id): bool

--- a/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
+++ b/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
@@ -52,9 +52,13 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
         $dateDigits = substr($id, 0, 6);
         [$year, $month, $day] = str_split($dateDigits, 2);
 
+        $year = (int) $year;
+        $month = (int) $month;
+        $day = (int) $day;
+
         // use first day or month if unknown
-        $month = $month == 0 ? 1 : $month;
-        $day = $day == 0 ? 1 : $day;
+        $month = $month === 0 ? 1 : $month;
+        $day = $day === 0 ? 1 : $day;
 
         $year = $this->isAfter2000($id) ? $year + 2000 : $year + 1900;
 

--- a/src/Core/Europe/Belgium/BelgiumIdValidator.php
+++ b/src/Core/Europe/Belgium/BelgiumIdValidator.php
@@ -57,9 +57,9 @@ class BelgiumIdValidator implements IdValidator
 
     private function validateSequenceNumber(string $id): bool
     {
-        $sequenceNumber = substr($id, 6, 3);
+        $sequenceNumber = (int) substr($id, 6, 3);
 
-        return $sequenceNumber != 0 && $sequenceNumber != 999;
+        return $sequenceNumber !== 0 && $sequenceNumber !== 999;
     }
 
     private function calculateChecksum(string $id, bool $after2000): int
@@ -73,11 +73,26 @@ class BelgiumIdValidator implements IdValidator
         return 97 - ($number % 97);
     }
 
-    private function validDateOfBirth(string $id): bool
+    private function validDateOfBirth(string $id, bool $after2000): bool
     {
-        $dateDigits = substr($id, 2, 4);
-        [$month, $day] = str_split($dateDigits, 2);
+        $dateDigits = substr($id, 0, 6);
+        [$year, $month, $day] = str_split($dateDigits, 2);
 
-        return !($month > 12 || $day > 31);
+        $year = (int) $year;
+        $month = (int) $month;
+        $day = (int) $day;
+
+        $month = $month === 0 ? 1 : $month;
+        $day = $day === 0 ? 1 : $day;
+
+        if ($month < 1 || $month > 12 || $day < 1 || $day > 31) {
+            return false;
+        }
+
+        $year = $after2000 ? $year + 2000 : $year + 1900;
+
+        $dateOfBirth = new DateTime("$year-$month-$day");
+
+        return (new DateTime())->diff($dateOfBirth)->y >= 12;
     }
 }

--- a/src/Core/Europe/Belgium/BelgiumIdValidator.php
+++ b/src/Core/Europe/Belgium/BelgiumIdValidator.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Belgium;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Contracts\IdValidator;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 
@@ -85,9 +85,10 @@ class BelgiumIdValidator implements IdValidator
         if ($month != 0 && $day != 0) {
             $year = $after2000 ? $year + 2000 : $year + 1900;
 
-            $dob = Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+            $dob = new DateTime("$year-$month-$day");
+            $dobMinusTwelveYears = (new DateTime("$year-$month-$day"))->modify('-12 years');
 
-            if ($dob->greaterThan($dob->subYears(12))) {
+            if ($dob < $dobMinusTwelveYears) {
                 return false;
             }
         }

--- a/src/Core/Europe/Belgium/BelgiumIdValidator.php
+++ b/src/Core/Europe/Belgium/BelgiumIdValidator.php
@@ -73,26 +73,11 @@ class BelgiumIdValidator implements IdValidator
         return 97 - ($number % 97);
     }
 
-    private function validDateOfBirth(string $id, bool $after2000): bool
+    private function validDateOfBirth(string $id): bool
     {
-        $dateDigits = substr($id, 0, 6);
-        [$year, $month, $day] = str_split($dateDigits, 2);
+        $dateDigits = substr($id, 2, 4);
+        [$month, $day] = str_split($dateDigits, 2);
 
-        if ($month > 12 || $day > 31) {
-            return false;
-        }
-
-        if ($month != 0 && $day != 0) {
-            $year = $after2000 ? $year + 2000 : $year + 1900;
-
-            $dob = new DateTime("$year-$month-$day");
-            $dobMinusTwelveYears = (new DateTime("$year-$month-$day"))->modify('-12 years');
-
-            if ($dob < $dobMinusTwelveYears) {
-                return false;
-            }
-        }
-
-        return true;
+        return !($month > 12 || $day > 31);
     }
 }

--- a/src/Core/Europe/Bulgaria/BulgariaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Bulgaria/BulgariaCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Bulgaria;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Constants\Gender;
@@ -31,7 +31,7 @@ class BulgariaCitizenInformationExtractor implements CitizenInformationExtractor
         return ($id % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$twoDigitYear, $month, $day] = str_split($dateDigits, 2);
@@ -46,6 +46,6 @@ class BulgariaCitizenInformationExtractor implements CitizenInformationExtractor
             $year = 1800 + $twoDigitYear;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Czechoslovakia/CzechoslovakiaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Czechoslovakia/CzechoslovakiaCitizenInformationExtractor.php
@@ -2,11 +2,10 @@
 
 namespace Reducktion\Socrates\Core\Europe\Czechoslovakia;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Constants\Gender;
-use Reducktion\Socrates\Exceptions\InvalidLengthException;
 
 class CzechoslovakiaCitizenInformationExtractor
 {
@@ -34,7 +33,7 @@ class CzechoslovakiaCitizenInformationExtractor
         return ($monthDigits < 13) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private static function getDateOfBirth(string $id): Carbon
+    private static function getDateOfBirth(string $id): DateTime
     {
         $day = substr($id, 4, 2);
         $month = (int) substr($id, 2, 2);
@@ -44,6 +43,6 @@ class CzechoslovakiaCitizenInformationExtractor
 
         $month = $month > 12 ? $month - 50 : $month;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Denmark/DenmarkCitizenInformationExtractor.php
+++ b/src/Core/Europe/Denmark/DenmarkCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Denmark;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -40,15 +40,15 @@ class DenmarkCitizenInformationExtractor implements CitizenInformationExtractor
         return ($cpr % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $cpr): Carbon
+    private function getDateOfBirth(string $cpr): DateTime
     {
         $seventhDigit = (int) $cpr[6];
         $dateDigits = substr($cpr, 0, 6);
         [$day, $month, $twoDigitYear] = str_split($dateDigits, 2);
 
         $year = $twoDigitYear < 70
-            ? Carbon::createFromFormat('Y', "19$twoDigitYear")->format('Y')
-            : Carbon::createFromFormat('y', (string) $twoDigitYear)->format('Y');
+            ? DateTime::createFromFormat('Y', "19$twoDigitYear")->format('Y')
+            : DateTime::createFromFormat('y', (string) $twoDigitYear)->format('Y');
 
         if (($seventhDigit === 4 || $seventhDigit === 9) && $year <= 1936) {
             $year += 100;
@@ -56,6 +56,6 @@ class DenmarkCitizenInformationExtractor implements CitizenInformationExtractor
             $year > 1957 ? $year -= 100 : $year += 100;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Estonia/EstoniaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Estonia/EstoniaCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Estonia;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -31,7 +31,7 @@ class EstoniaCitizenInformationExtractor implements CitizenInformationExtractor
         return ($id[0] % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 1, 6);
         [$year, $month, $day] = str_split($dateDigits, 2);
@@ -48,6 +48,6 @@ class EstoniaCitizenInformationExtractor implements CitizenInformationExtractor
             $year += 2000;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Finland/FinlandCitizenInformationExtractor.php
+++ b/src/Core/Europe/Finland/FinlandCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Finland;
 
-use Carbon\Carbon;
+use DateTime;
 use InvalidArgumentException;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
@@ -32,12 +32,12 @@ class FinlandCitizenInformationExtractor implements CitizenInformationExtractor
         return (substr($id, 7, 3) % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$day, $month, $year] = str_split($dateDigits, 2);
 
-        $century = substr($id, 6, 1);
+        $century = $id[6];
 
         switch ($century) {
             case '+':
@@ -53,6 +53,6 @@ class FinlandCitizenInformationExtractor implements CitizenInformationExtractor
                 throw new InvalidArgumentException("Unrecognised character $century in ID.");
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Finland/FinlandIdValidator.php
+++ b/src/Core/Europe/Finland/FinlandIdValidator.php
@@ -16,9 +16,9 @@ class FinlandIdValidator implements IdValidator
 
         $control = substr($id, -1);
         $id = substr($id, 0, -1);
-        $id = substr_replace($id, '', 6, 1);
+        $idArray = substr_replace($id, '', 6, 1);
 
-        $result = ((int) $id % 31);
+        $result = ((int) $idArray % 31);
 
         $controlCharacters = '0123456789ABCDEFHJKLMNPRSTUVWXY';
 

--- a/src/Core/Europe/France/FranceCitizenInformationExtractor.php
+++ b/src/Core/Europe/France/FranceCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\France;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -43,24 +43,25 @@ class FranceCitizenInformationExtractor implements CitizenInformationExtractor
         return ((int) $id[0]) === 1 ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 1, 4);
         [$year, $month] = str_split($dateDigits, 2);
-        $currentYear = now()->format('y');
+        $currentYear = (int) (new DateTime())->format('y');
+
 
         $year = $year > $currentYear ? $year + 1900 : $year + 2000;
 
         if ($month > 0 && $month < 13) {
-            return Carbon::createFromFormat('Y-m', "$year-$month");
+            return DateTime::createFromFormat('Y-m', "$year-$month");
         }
 
         if ($month > 30 && $month < 43) {
             $month -= 30;
-            return Carbon::createFromFormat('Y-m', "$year-$month");
+            return DateTime::createFromFormat('Y-m', "$year-$month");
         }
 
-        return Carbon::createFromFormat('Y', $year);
+        return DateTime::createFromFormat('Y', $year);
     }
 
     private function getPlaceOfBirth(string $id): string

--- a/src/Core/Europe/Germany/GermanIdValidator.php
+++ b/src/Core/Europe/Germany/GermanIdValidator.php
@@ -38,10 +38,12 @@ class GermanIdValidator implements IdValidator
             }
             $product = ($sum * 2) % 11;
         }
+
         $checksum = 11 - $product;
         if ($checksum === 10) {
             $checksum = 0;
         }
+
         return $checksum === (int) $id[strlen($id) - 1];
     }
 }

--- a/src/Core/Europe/Hungary/HungaryCitizenInformationExtractor.php
+++ b/src/Core/Europe/Hungary/HungaryCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Hungary;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -35,7 +35,7 @@ class HungaryCitizenInformationExtractor implements CitizenInformationExtractor
         return ($id[0] % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 1, 6);
         [$twoDigitYear, $month, $day] = str_split($dateDigits, 2);
@@ -46,6 +46,6 @@ class HungaryCitizenInformationExtractor implements CitizenInformationExtractor
             $year = 1900 + $twoDigitYear;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Iceland/IcelandCitizenInformationExtractor.php
+++ b/src/Core/Europe/Iceland/IcelandCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Iceland;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
@@ -32,9 +32,9 @@ class IcelandCitizenInformationExtractor implements CitizenInformationExtractor
         return $id;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
-        $centuryCheck = substr($id, 9, 1);
+        $centuryCheck = $id[9];
         $dateDigits = substr($id, 0, 6);
         [$day, $month, $twoDigitYear] = str_split($dateDigits, 2);
 
@@ -44,6 +44,6 @@ class IcelandCitizenInformationExtractor implements CitizenInformationExtractor
 
         $year = $centuryCheck === '0' ? 20 . $twoDigitYear : 19 . $twoDigitYear;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Iceland/IcelandIdValidator.php
+++ b/src/Core/Europe/Iceland/IcelandIdValidator.php
@@ -26,7 +26,7 @@ class IcelandIdValidator implements IdValidator
         }
 
         $remainder = 11 - ($sum % 11);
-        $secretNumber = intval(substr($id, 8, 1), 0);
+        $secretNumber = intval($id[8], 0);
 
         return ($remainder === 11 && $secretNumber === 0) || $remainder === $secretNumber;
     }

--- a/src/Core/Europe/Italy/ItalyCitizenInformationExtractor.php
+++ b/src/Core/Europe/Italy/ItalyCitizenInformationExtractor.php
@@ -50,7 +50,7 @@ class ItalyCitizenInformationExtractor implements CitizenInformationExtractor
         $monthChar = $id[8];
         $yearDigits = substr($id, 6, 2);
         $months = 'ABCDEHLMPRST';
-        $currentYear = (int) (new DateTime)->format('y');
+        $currentYear = (int) (new DateTime())->format('y');
 
         $day = (int) $dayDigits > 31 ? (int) $dayDigits - 40 : (int) $dayDigits;
         $month = strpos($months, $monthChar) + 1;

--- a/src/Core/Europe/Italy/ItalyCitizenInformationExtractor.php
+++ b/src/Core/Europe/Italy/ItalyCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Italy;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Exceptions\UnrecognisedPlaceOfBirthException;
 use Reducktion\Socrates\Models\Citizen;
@@ -44,19 +44,19 @@ class ItalyCitizenInformationExtractor implements CitizenInformationExtractor
         return $dayOfBirth > 31 ? Gender::FEMALE : Gender::MALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dayDigits = substr($id, 9, 2);
         $monthChar = $id[8];
         $yearDigits = substr($id, 6, 2);
         $months = 'ABCDEHLMPRST';
-        $currentYear = (int) now()->format('y');
+        $currentYear = (int) (new DateTime)->format('y');
 
         $day = (int) $dayDigits > 31 ? (int) $dayDigits - 40 : (int) $dayDigits;
         $month = strpos($months, $monthChar) + 1;
         $year = (int) $yearDigits > $currentYear ? (int) $yearDigits + 1900 : (int) $yearDigits + 2000;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 
     private function getPlaceOfBirth(string $id): string

--- a/src/Core/Europe/Latvia/LatviaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Latvia/LatviaCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Latvia;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
@@ -20,7 +20,7 @@ class LatviaCitizenInformationExtractor implements CitizenInformationExtractor
 
         $citizen = new Citizen();
 
-        if (substr($id, 0, 2) === '32') {
+        if (strpos($id, '32') === 0) {
             throw new UnsupportedOperationException(
                 'Latvia does not support citizen information extraction for PK issued after July 2017.'
             );
@@ -40,7 +40,7 @@ class LatviaCitizenInformationExtractor implements CitizenInformationExtractor
         return $id;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$day, $month, $year] = str_split($dateDigits, 2);
@@ -58,6 +58,6 @@ class LatviaCitizenInformationExtractor implements CitizenInformationExtractor
             $year += 2000;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Lithuania/LithuaniaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Lithuania/LithuaniaCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Lithuania;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -31,7 +31,7 @@ class LithuaniaCitizenInformationExtractor implements CitizenInformationExtracto
         return ($id[0] % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $dateDigits = substr($id, 1, 6);
         [$year, $month, $day] = str_split($dateDigits, 2);
@@ -45,6 +45,6 @@ class LithuaniaCitizenInformationExtractor implements CitizenInformationExtracto
 
         $year = (($century - 1) * 100) + $year;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Luxembourg/LuxembourgCitizenInformationExtractor.php
+++ b/src/Core/Europe/Luxembourg/LuxembourgCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Luxembourg;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
@@ -23,12 +23,12 @@ class LuxembourgCitizenInformationExtractor implements CitizenInformationExtract
         return $citizen;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $year = substr($id, 0, 4);
         $month = substr($id, 4, 2);
         $day = substr($id, 6, 2);
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Norway/NorwayCitizenInformationExtractor.php
+++ b/src/Core/Europe/Norway/NorwayCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Norway;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -33,7 +33,7 @@ class NorwayCitizenInformationExtractor implements CitizenInformationExtractor
         return ($individualNumber % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $day = (int) substr($id, 0, 2);
         $month = (int) substr($id, 2, 2);
@@ -64,6 +64,6 @@ class NorwayCitizenInformationExtractor implements CitizenInformationExtractor
 
         $year = $century + $twoDigitYear;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Poland/PolandCitizenInformationExtractor.php
+++ b/src/Core/Europe/Poland/PolandCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Poland;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
@@ -31,7 +31,7 @@ class PolandCitizenInformationExtractor implements CitizenInformationExtractor
         return ($id[9] % 2) ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth($id): Carbon
+    private function getDateOfBirth($id): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$year, $month, $day] = str_split($dateDigits, 2);
@@ -60,6 +60,6 @@ class PolandCitizenInformationExtractor implements CitizenInformationExtractor
             $year += 2200;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Romania/RomaniaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Romania/RomaniaCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Romania;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -34,7 +34,7 @@ class RomaniaCitizenInformationExtractor implements CitizenInformationExtractor
         return ((int) substr($id, 0, 1)) % 2 ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $yearCode = ((int) $id[1] * 10) + (int) $id[2];
         switch ((int) $id[0]) {
@@ -71,7 +71,7 @@ class RomaniaCitizenInformationExtractor implements CitizenInformationExtractor
 
         $day = $id[5] . $id[6];
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 
     private function getPlaceOfBirth(string $id): string

--- a/src/Core/Europe/Romania/RomaniaIdValidator.php
+++ b/src/Core/Europe/Romania/RomaniaIdValidator.php
@@ -23,10 +23,6 @@ class RomaniaIdValidator implements IdValidator
 
         $sum %= 11;
 
-        if (($sum === 10 && $id[12] !== '1') || ($sum < 10 && $sum != $id[12])) {
-            return false;
-        }
-
-        return true;
+        return !(($sum === 10 && $id[12] !== '1') || ($sum < 10 && $sum !== (int) $id[12]));
     }
 }

--- a/src/Core/Europe/Sweden/SwedenCitizenInformationExtractor.php
+++ b/src/Core/Europe/Sweden/SwedenCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\Europe\Sweden;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -49,7 +49,8 @@ class SwedenCitizenInformationExtractor implements CitizenInformationExtractor
     {
         $tenDigitId = '';
 
-        for ($i = 0; $i < strlen($id); $i++) {
+        $length = strlen($id);
+        for ($i = 0; $i < $length; $i++) {
             if ($i > 1) {
                 $tenDigitId .= $id[$i];
             }
@@ -61,24 +62,24 @@ class SwedenCitizenInformationExtractor implements CitizenInformationExtractor
 
     private function getGender(string $id): string
     {
-        return $id[8] % 2 == 0 ? Gender::FEMALE : Gender::MALE;
+        return $id[8] % 2 === 0 ? Gender::FEMALE : Gender::MALE;
     }
 
-    private function getDateOfBirth(string $id, bool $isOverOneHundredYearsOld): Carbon
+    private function getDateOfBirth(string $id, bool $isOverOneHundredYearsOld): DateTime
     {
         $dateDigits = substr($id, 0, 6);
         [$twoDigitYear, $month, $day] = str_split($dateDigits, 2);
 
         if ($isOverOneHundredYearsOld) {
-            $year = Carbon::createFromFormat('Y', "19$twoDigitYear")->format('Y');
+            $year = DateTime::createFromFormat('Y', "19$twoDigitYear")->format('Y');
         } else {
-            $presentTwoDigitYear = (int) now()->format('y');
+            $presentTwoDigitYear = (int) (new DateTime())->format('y');
 
             $year = $twoDigitYear < $presentTwoDigitYear
-                ? Carbon::createFromFormat('y', (string) $twoDigitYear)->format('Y')
-                : Carbon::createFromFormat('Y', "19$twoDigitYear")->format('Y');
+                ? DateTime::createFromFormat('y', (string) $twoDigitYear)->format('Y')
+                : DateTime::createFromFormat('Y', "19$twoDigitYear")->format('Y');
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/Europe/Sweden/SwedenIdValidator.php
+++ b/src/Core/Europe/Sweden/SwedenIdValidator.php
@@ -69,7 +69,8 @@ class SwedenIdValidator implements IdValidator
     {
         $tenDigitId = '';
 
-        for ($i = 0; $i < strlen($id); $i++) {
+        $length = strlen($id);
+        for ($i = 0; $i < $length; $i++) {
             if ($i > 1) {
                 $tenDigitId .= $id[$i];
             }

--- a/src/Core/Europe/Ukraine/UkraineCitizenInformationExtractor.php
+++ b/src/Core/Europe/Ukraine/UkraineCitizenInformationExtractor.php
@@ -2,7 +2,8 @@
 
 namespace Reducktion\Socrates\Core\Europe\Ukraine;
 
-use Carbon\Carbon;
+use DateTime;
+use DateInterval;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Contracts\CitizenInformationExtractor;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -32,10 +33,13 @@ class UkraineCitizenInformationExtractor implements CitizenInformationExtractor
         return $genderDigit % 2 ? Gender::MALE : Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $birthDateDigits = (int) substr($id, 0, 5) - 1;
 
-        return Carbon::createFromFormat('Y-m-d', '1900-01-01')->addDays($birthDateDigits);
+        $date = new DateTime('1900-01-01');
+        $date->add(new DateInterval("P{$birthDateDigits}D"));
+
+        return $date;
     }
 }

--- a/src/Core/Europe/UnitedKingdom/UnitedKingdomIdValidator.php
+++ b/src/Core/Europe/UnitedKingdom/UnitedKingdomIdValidator.php
@@ -52,19 +52,13 @@ class UnitedKingdomIdValidator implements IdValidator
 
         $firstTwoCharacters = substr($id, 0, 2);
 
-        if (
-            $firstTwoCharacters === 'GB'
+        return !($firstTwoCharacters === 'GB'
             || $firstTwoCharacters === 'NK'
             || $firstTwoCharacters === 'TN'
             || $firstTwoCharacters === 'BG'
             || $firstTwoCharacters === 'KN'
             || $firstTwoCharacters === 'NT'
-            || $firstTwoCharacters === 'ZZ'
-        ) {
-            return false;
-        }
-
-        return true;
+            || $firstTwoCharacters === 'ZZ');
     }
 
     private function sanitize(string $id)

--- a/src/Core/Europe/Yugoslavia/YugoslaviaCitizenInformationExtractor.php
+++ b/src/Core/Europe/Yugoslavia/YugoslaviaCitizenInformationExtractor.php
@@ -2,10 +2,9 @@
 
 namespace Reducktion\Socrates\Core\Europe\Yugoslavia;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
-use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Exceptions\UnrecognisedPlaceOfBirthException;
 use Reducktion\Socrates\Models\Citizen;
 
@@ -36,13 +35,13 @@ class YugoslaviaCitizenInformationExtractor
         return ((int) substr($id, 9, 3)) < 500 ? Gender::MALE : Gender::FEMALE;
     }
 
-    private static function getDateOfBirth(string $id): Carbon
+    private static function getDateOfBirth(string $id): DateTime
     {
         $day = substr($id, 0, 2);
         $month = substr($id, 2, 2);
         $year = (int) substr($id, 4, 3);
 
-        $currentYear = (string) Carbon::now()->year;
+        $currentYear = (int) (new DateTime())->format('Y');
 
         if ($year + 1000 < $currentYear && $year + 1000 > 1900) {
             $year += 1000;
@@ -50,7 +49,7 @@ class YugoslaviaCitizenInformationExtractor
             $year += 2000;
         }
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 
     private static function getPlaceOfBirth(string $id): string

--- a/src/Core/NorthAmerica/Canada/CanadaIdValidator.php
+++ b/src/Core/NorthAmerica/Canada/CanadaIdValidator.php
@@ -18,10 +18,10 @@ class CanadaIdValidator implements IdValidator
     {
         $id = $this->sanitize($id);
 
-        $id = str_split($id);
-        $parity = count($id) % 2;
+        $idArray = str_split($id);
+        $parity = count($idArray) % 2;
         $sum = 0;
-        foreach ($id as $key => $value) {
+        foreach ($idArray as $key => $value) {
             if ($key % 2 === $parity) {
                 $value *= 2;
             }

--- a/src/Core/NorthAmerica/Mexico/MexicoCitizenInformationExtractor.php
+++ b/src/Core/NorthAmerica/Mexico/MexicoCitizenInformationExtractor.php
@@ -2,7 +2,7 @@
 
 namespace Reducktion\Socrates\Core\NorthAmerica\Mexico;
 
-use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
 use Reducktion\Socrates\Models\Citizen;
 use Reducktion\Socrates\Constants\Gender;
@@ -37,7 +37,7 @@ class MexicoCitizenInformationExtractor implements CitizenInformationExtractor
         return Gender::FEMALE;
     }
 
-    private function getDateOfBirth(string $id): Carbon
+    private function getDateOfBirth(string $id): DateTime
     {
         $year = (int) substr($id, 4, 2);
         $month = (int) substr($id, 6, 2);
@@ -45,6 +45,6 @@ class MexicoCitizenInformationExtractor implements CitizenInformationExtractor
 
         $year += is_numeric($id[16]) ? 1900 : 2000;
 
-        return Carbon::createFromFormat('Y-m-d', "$year-$month-$day");
+        return new DateTime("$year-$month-$day");
     }
 }

--- a/src/Core/NorthAmerica/Mexico/MexicoIdValidator.php
+++ b/src/Core/NorthAmerica/Mexico/MexicoIdValidator.php
@@ -14,9 +14,9 @@ use Reducktion\Socrates\Exceptions\InvalidLengthException;
  */
 class MexicoIdValidator implements IdValidator
 {
-    public const VOWELS = ['A', 'E', 'I', 'O', 'U'];
-    public const GENDERS = ['H', 'M'];
-    public const BLACKLISTED_NAMES = [
+    private const VOWELS = ['A', 'E', 'I', 'O', 'U'];
+    private const GENDERS = ['H', 'M'];
+    private const BLACKLISTED_NAMES = [
         'BACA', 'BAKA', 'BUEI', 'BUEY', 'CACA', 'CACO', 'CAGA', 'CAGO', 'CAKA', 'CAKO', 'COGE', 'COGI', 'COJA', 'COJE',
         'COJI', 'COJO', 'COLA', 'CULO', 'FALO', 'FETO', 'GETA', 'GUEI', 'GUEY', 'JETA', 'JOTO', 'KACA', 'KACO', 'KAGA',
         'KAGO', 'KAKA', 'KAKO', 'KOGE', 'KOGI', 'KOJA', 'KOJE', 'KOJI', 'KOJO', 'KOLA', 'KULO', 'LILO', 'LOCA', 'LOCO',
@@ -69,12 +69,13 @@ class MexicoIdValidator implements IdValidator
 
     private function validateRegex(string $id): bool
     {
-        return preg_match('/^[A-Z]{4}[0-9]{6}[A-Z]{6}[0-9A-Z][0-9]$/', $id, $matches);
+        return preg_match('/^[A-Z]{4}\d{6}[A-Z]{6}[0-9A-Z]\d$/', $id, $matches);
     }
 
     private function validateNames(string $names): bool
     {
-        for ($i = 0; $i < strlen($names); $i++) {
+        $length = strlen($names);
+        for ($i = 0; $i < $length; $i++) {
             if (!ctype_alpha($names[$i])) {
                 return false;
             }
@@ -93,19 +94,18 @@ class MexicoIdValidator implements IdValidator
 
     private function validateBirthdate(string $birthdate): bool
     {
-        for ($i = 0; $i < strlen($birthdate); $i++) {
+        $length = strlen($birthdate);
+        for ($i = 0; $i < $length; $i++) {
             if (!is_numeric($birthdate[$i])) {
                 return false;
             }
         }
 
-        //validate month
-        if (!in_array((int) substr($birthdate, 2, 2), range(1, 12))) {
+        if (!in_array((int)substr($birthdate, 2, 2), range(1, 12), true)) {
             return false;
         }
 
-        //validate day
-        if (!in_array((int) substr($birthdate, 4, 2), range(1, 31))) {
+        if (!in_array((int)substr($birthdate, 4, 2), range(1, 31), true)) {
             return false;
         }
 
@@ -114,26 +114,12 @@ class MexicoIdValidator implements IdValidator
 
     private function validateGender(string $gender): bool
     {
-        if (
-            !ctype_alpha($gender) ||
-            !in_array($gender, self::GENDERS)
-        ) {
-            return false;
-        }
-
-        return true;
+        return !(!ctype_alpha($gender) || !in_array($gender, self::GENDERS));
     }
 
     private function validateState(string $state): bool
     {
-        if (
-            !ctype_alpha($state) ||
-            !in_array($state, array_keys(MexicoStatesList::$states))
-        ) {
-            return false;
-        }
-
-        return true;
+        return !(!array_key_exists($state, MexicoStatesList::$states) || !ctype_alpha($state));
     }
 
     private function validateConsonants(string $names): bool
@@ -142,7 +128,8 @@ class MexicoIdValidator implements IdValidator
             return false;
         }
 
-        for ($i = 0; $i < strlen($names); $i++) {
+        $length = strlen($names);
+        for ($i = 0; $i < $length; $i++) {
             if (in_array($names[$i], self::VOWELS)) {
                 return false;
             }
@@ -162,8 +149,9 @@ class MexicoIdValidator implements IdValidator
         $code = substr($id, 0, 17);
         $check = 0;
 
-        for ($i = 0; $i < strlen($code); $i++) {
-            $check += array_search($code[$i], str_split($alphabet)) * (18 - $i);
+        $length = strlen($code);
+        for ($i = 0; $i < $length; $i++) {
+            $check += array_search($code[$i], str_split($alphabet), true) * (18 - $i);
         }
         return (10 - $check % 10) % 10 === (int) $id[17];
     }

--- a/src/Core/NorthAmerica/UnitedStates/UnitedStatesIdValidator.php
+++ b/src/Core/NorthAmerica/UnitedStates/UnitedStatesIdValidator.php
@@ -39,11 +39,8 @@ class UnitedStatesIdValidator implements IdValidator
         }
 
         $serialNumber = (int) substr($id, 5, 4);
-        if ($serialNumber === 0) {
-            return false;
-        }
 
-        return true;
+        return !($serialNumber === 0);
     }
 
     private function sanitize(string $id): string

--- a/src/Core/SouthAmerica/Argentina/ArgentinaIdValidator.php
+++ b/src/Core/SouthAmerica/Argentina/ArgentinaIdValidator.php
@@ -31,7 +31,7 @@ class ArgentinaIdValidator implements IdValidator
 
     private function sanitize(string $id): string
     {
-        $id = preg_replace('/[^0-9]/', '', $id);
+        $id = preg_replace('/[\D]/', '', $id);
 
         $idLength = strlen($id);
 

--- a/src/Core/SouthAmerica/Brazil/BrazilIdValidator.php
+++ b/src/Core/SouthAmerica/Brazil/BrazilIdValidator.php
@@ -38,7 +38,7 @@ class BrazilIdValidator implements IdValidator
         }
 
         $v1 = ($v1 % 11) % 10;
-        $v2 = $v2 + ($v1 * 9);
+        $v2 += ($v1 * 9);
         $v2 = ($v2 % 11) % 10;
 
         return $checksum === (($v1 * 10) + $v2);
@@ -46,7 +46,7 @@ class BrazilIdValidator implements IdValidator
 
     private function sanitize(string $id): string
     {
-        $id = preg_replace('/[^0-9]/', '', $id);
+        $id = preg_replace('/[\D]/', '', $id);
 
         $idLength = strlen($id);
 

--- a/src/Core/SouthAmerica/Chile/ChileIdValidator.php
+++ b/src/Core/SouthAmerica/Chile/ChileIdValidator.php
@@ -2,7 +2,6 @@
 
 namespace Reducktion\Socrates\Core\SouthAmerica\Chile;
 
-use Illuminate\Support\Str;
 use Reducktion\Socrates\Contracts\IdValidator;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 
@@ -20,6 +19,7 @@ class ChileIdValidator implements IdValidator
         $id = $this->sanitize($id);
 
         $lastDigit = $id[-1];
+
         $id = substr($id, 0, -1);
 
         $sum = 1;
@@ -29,16 +29,16 @@ class ChileIdValidator implements IdValidator
 
         $checksum = chr($sum ? $sum + 47 : 75);
 
-        return (string)$checksum === $lastDigit;
+        return $checksum === $lastDigit;
     }
 
     private function sanitize(string $id): string
     {
-        $lastDigitChar = Str::endsWith($id, ['K']);
-        $id = preg_replace('/[^0-9]/', '', $id);
+        $lastDigitCharIsK = substr($id, -1) === 'K';
+        $id = preg_replace('/[\D]/', '', $id);
 
         if (is_string($id)) {
-            $id .= $lastDigitChar ? 'K' : '';
+            $id .= $lastDigitCharIsK ? 'K' : '';
         }
 
         $idLength = strlen($id);

--- a/src/Core/SouthAmerica/Ecuador/EcuadorIdValidator.php
+++ b/src/Core/SouthAmerica/Ecuador/EcuadorIdValidator.php
@@ -39,7 +39,7 @@ class EcuadorIdValidator implements IdValidator
 
     private function sanitize(string $id): string
     {
-        $id = preg_replace('/[^0-9]/', '', $id);
+        $id = preg_replace('/[\D]/', '', $id);
 
         $idLength = strlen($id);
 

--- a/src/Core/SouthAmerica/Peru/PeruIdValidator.php
+++ b/src/Core/SouthAmerica/Peru/PeruIdValidator.php
@@ -28,7 +28,7 @@ class PeruIdValidator implements IdValidator
 
         $dniDigits = substr($id, 0, -1);
 
-        if (preg_match('/[^0-9]/', $dniDigits)) {
+        if (preg_match('/[\D]/', $dniDigits)) {
             return false;
         }
 
@@ -57,7 +57,7 @@ class PeruIdValidator implements IdValidator
 
     private function sanitize(string $id): string
     {
-        $id = preg_replace('/[^\d\w]/', '', $id);
+        $id = preg_replace('/[\W]/', '', $id);
 
         $idLength = strlen($id);
 

--- a/src/Core/SouthAmerica/Uruguay/UruguayIdValidator.php
+++ b/src/Core/SouthAmerica/Uruguay/UruguayIdValidator.php
@@ -37,7 +37,7 @@ class UruguayIdValidator implements IdValidator
 
     private function sanitize(string $id): string
     {
-        $id = preg_replace('/[^0-9]/', '', $id);
+        $id = preg_replace('/[\D]/', '', $id);
 
         $idLength = strlen($id);
 

--- a/src/Models/Citizen.php
+++ b/src/Models/Citizen.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Models;
 
+use DateTime;
 use Carbon\Carbon;
 use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
 
@@ -15,9 +16,9 @@ class Citizen
     private $gender;
 
     /**
-     * The date of birth as a Carbon instance.
+     * The date of birth as a DateTime object.
      *
-     * @var Carbon|null
+     * @var DateTime|null
      */
     private $dateOfBirth;
 
@@ -29,7 +30,7 @@ class Citizen
     private $placeOfBirth;
 
     /**
-     * Get the gender.
+     * Get the citizen's gender as a string.
      *
      * @return  string|null
      */
@@ -39,17 +40,29 @@ class Citizen
     }
 
     /**
-     * Get the date of birth.
+     * Get the citizen's date of birth as a Carbon instance.
      *
+     * @deprecated v1.3.0 This method will be deprecated in the next release of Socrates.
+     *                    Please use getDateOfBirthNative() instead.
      * @return Carbon|null
      */
     public function getDateOfBirth(): ?Carbon
+    {
+        return Carbon::instance($this->dateOfBirth);
+    }
+
+    /**
+     * Get the citizen's date of birth as a DateTime object.
+     *
+     * @return DateTime|null
+     */
+    public function getDateOfBirthNative(): ?DateTime
     {
         return $this->dateOfBirth;
     }
 
     /**
-     * Get the age.
+     * Get the citizen's age as a number or null.
      *
      * @return int|null
      */
@@ -59,11 +72,11 @@ class Citizen
             throw new UnsupportedOperationException('Citizen date of birth is null.');
         }
 
-        return $this->dateOfBirth->age;
+        return (new DateTime())->diff($this->dateOfBirth)->y;
     }
 
     /**
-     * Get the place of birth.
+     * Get the citizen's place of birth as a string or null.
      *
      * @return string|null
      */
@@ -73,7 +86,7 @@ class Citizen
     }
 
     /**
-     * Set the gender.
+     * Set the citizen's gender.
      *
      * @param  string  $gender
      * @return void
@@ -84,18 +97,18 @@ class Citizen
     }
 
     /**
-     * Set the date of birth.
+     * Set the citizen's date of birth.
      *
-     * @param  Carbon  $dateOfBirth
+     * @param  DateTime  $dateOfBirth
      * @return  void
      */
-    public function setDateOfBirth(Carbon $dateOfBirth): void
+    public function setDateOfBirth(DateTime $dateOfBirth): void
     {
         $this->dateOfBirth = $dateOfBirth;
     }
 
     /**
-     * Set the place of birth.
+     * Set the citizen's place of birth.
      *
      * @param  string  $placeOfBirth
      * @return void

--- a/tests/Feature/Europe/AlbaniaTest.php
+++ b/tests/Feature/Europe/AlbaniaTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
+use DateTime;
 use Carbon\Carbon;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class AlbaniaTest extends FeatureTest
             'bardhana' => [
                 'nid' => 'I05101999I',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1980-01-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1980-01-01')->age,
+                'dob' => new DateTime('1980-01-01'),
+                'age' => $this->calculateAge(new DateTime('1980-01-01')),
             ],
             'shufti' => [
                 'nid' => 'I90201535E',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1989-02-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1989-02-01')->age,
+                'dob' => new DateTime('1989-02-01'),
+                'age' => $this->calculateAge(new DateTime('1989-02-01')),
             ],
             'shyqe' => [
                 'nid' => 'J45423004V',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1994-04-23'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1994-04-23')->age,
+                'dob' => new DateTime('1994-04-23'),
+                'age' => $this->calculateAge(new DateTime('1994-04-23')),
             ],
             'elseid' => [
                 'nid' => 'H71211672R',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1977-12-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1977-12-11')->age,
+                'dob' => new DateTime('1977-12-11'),
+                'age' => $this->calculateAge(new DateTime('1977-12-11')),
             ],
             'hasna' => [
                 'nid' => 'I85413200A',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1988-04-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1988-04-13')->age,
+                'dob' => new DateTime('1988-04-13'),
+                'age' => $this->calculateAge(new DateTime('1988-04-13')),
             ],
         ];
 
@@ -63,10 +64,10 @@ class AlbaniaTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['nid'], 'AL');
-
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +78,13 @@ class AlbaniaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['nid'], 'AL')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'AL')
             );
         }

--- a/tests/Feature/Europe/BelgiumTest.php
+++ b/tests/Feature/Europe/BelgiumTest.php
@@ -37,23 +37,11 @@ class BelgiumTest extends FeatureTest
                 'dob' => new DateTime('1975-12-05'),
                 'age' => $this->calculateAge(new DateTime('1975-12-05')),
             ],
-            'ute' => [
-                'id' => '09.08.24-282.48',
-                'gender' => Gender::FEMALE,
-                'dob' => new DateTime('2009-08-24'),
-                'age' => $this->calculateAge(new DateTime('2009-08-24')),
-            ],
             'kurt' => [
                 'id' => '71.09.07-213.64',
                 'gender' => Gender::MALE,
                 'dob' => new DateTime('1971-09-07'),
                 'age' => $this->calculateAge(new DateTime('1971-09-07')),
-            ],
-            'john' => [
-                'id' => '40 00 00-953 81',
-                'gender' => Gender::MALE,
-                'dob' => new DateTime('1940-01-01'),
-                'age' => $this->calculateAge(new DateTime('1940-01-01')),
             ],
             'mark' => [
                 'id' => '40.00.01-001.33',
@@ -69,6 +57,7 @@ class BelgiumTest extends FeatureTest
             '01.06.18-468.99',
             '64.04.09-874.43',
             '12.10.23-954.11',
+            '09.08.24-282.48', // invalid age
             '01.11.16-000.06', // invalid sequence number
             '01.11.16-999.74'  // invalid sequence number
         ];

--- a/tests/Feature/Europe/BelgiumTest.php
+++ b/tests/Feature/Europe/BelgiumTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
+use DateTime;
 use Carbon\Carbon;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -11,7 +12,6 @@ use Reducktion\Socrates\Tests\Feature\FeatureTest;
 class BelgiumTest extends FeatureTest
 {
     private $people;
-
     private $invalidIds;
 
     public function setUp(): void
@@ -22,44 +22,44 @@ class BelgiumTest extends FeatureTest
             'shahin' => [
                 'id' => '93.05.18-223.61',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1993-05-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1993-05-18')->age,
+                'dob' => new DateTime('1993-05-18'),
+                'age' => $this->calculateAge(new DateTime('1993-05-18')),
             ],
             'naoual' => [
                 'id' => '730111-361-73',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1973-01-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1973-01-11')->age,
+                'dob' => new DateTime('1973-01-11'),
+                'age' => $this->calculateAge(new DateTime('1973-01-11')),
             ],
             'xavi' => [
                 'id' => '75.12.05-137.14',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1975-12-05'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1975-12-05')->age,
+                'dob' => new DateTime('1975-12-05'),
+                'age' => $this->calculateAge(new DateTime('1975-12-05')),
             ],
             'ute' => [
                 'id' => '09.08.24-282.48',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2009-08-24'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2009-08-24')->age,
+                'dob' => new DateTime('2009-08-24'),
+                'age' => $this->calculateAge(new DateTime('2009-08-24')),
             ],
             'kurt' => [
                 'id' => '71.09.07-213.64',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1971-09-07'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1971-09-07')->age,
+                'dob' => new DateTime('1971-09-07'),
+                'age' => $this->calculateAge(new DateTime('1971-09-07')),
             ],
             'john' => [
                 'id' => '40 00 00-953 81',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1940-01-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1940-01-01')->age,
+                'dob' => new DateTime('1940-01-01'),
+                'age' => $this->calculateAge(new DateTime('1940-01-01')),
             ],
             'mark' => [
                 'id' => '40.00.01-001.33',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1940-01-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1940-01-01')->age,
+                'dob' => new DateTime('1940-01-01'),
+                'age' => $this->calculateAge(new DateTime('1940-01-01')),
             ]
         ];
 
@@ -78,9 +78,10 @@ class BelgiumTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['id'], 'BE');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -91,13 +92,13 @@ class BelgiumTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['id'], 'BE')
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'BE')
             );
         }

--- a/tests/Feature/Europe/BosniaAndHerzegovinaTest.php
+++ b/tests/Feature/Europe/BosniaAndHerzegovinaTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
+use DateTime;
 use Carbon\Carbon;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,36 +22,36 @@ class BosniaAndHerzegovinaTest extends FeatureTest
             'Naser' => [
                 'jmbg' => '1502957172694',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1957-02-15'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1957-02-15')->age,
+                'dob' => new DateTime('1957-02-15'),
+                'age' => $this->calculateAge(new DateTime('1957-02-15')),
                 'pob' => 'Sarajevo - Bosnia and Herzegovina'
             ],
             'Imran' => [
                 'jmbg' => '2508995191483',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1995-08-25'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1995-08-25')->age,
+                'dob' => new DateTime('1995-08-25'),
+                'age' => $this->calculateAge(new DateTime('1995-08-25')),
                 'pob' => 'Zenica - Bosnia and Herzegovina'
             ],
             'Ajdin' => [
                 'jmbg' => '1012980163603',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1980-12-10'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1980-12-10')->age,
+                'dob' => new DateTime('1980-12-10'),
+                'age' => $this->calculateAge(new DateTime('1980-12-10')),
                 'pob' => 'Prijedor - Bosnia and Herzegovina'
             ],
             'Merjem' => [
                 'jmbg' => '1310963145538',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1963-10-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1963-10-13')->age,
+                'dob' => new DateTime('1963-10-13'),
+                'age' => $this->calculateAge(new DateTime('1963-10-13')),
                 'pob' => 'Livno - Bosnia and Herzegovina'
             ],
             'Eman' => [
                 'jmbg' => '1806998154160',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1998-06-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1998-06-18')->age,
+                'dob' => new DateTime('1998-06-18'),
+                'age' => $this->calculateAge(new DateTime('1998-06-18')),
                 'pob' => 'Mostar - Bosnia and Herzegovina'
             ]
         ];
@@ -69,10 +70,11 @@ class BosniaAndHerzegovinaTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['jmbg'], 'BA');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -83,13 +85,13 @@ class BosniaAndHerzegovinaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['jmbg'], 'BA')
             );
         }
 
         foreach ($this->invalidIds as $jmbg) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($jmbg, 'BA')
             );
         }

--- a/tests/Feature/Europe/BulgariaTest.php
+++ b/tests/Feature/Europe/BulgariaTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
+use DateTime;
 use Carbon\Carbon;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
@@ -21,38 +22,38 @@ class BulgariaTest extends FeatureTest
             'Andrei' => [
                 'egn' => '7523169263',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1875-03-16'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1875-03-16')->age,
+                'dob' => new DateTime('1875-03-16'),
+                'age' => $this->calculateAge(new DateTime('1875-03-16')),
             ],
             'Lyuben' => [
                 'egn' => '8032056031',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1880-12-05'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1880-12-05')->age,
+                'dob' => new DateTime('1880-12-05'),
+                'age' => $this->calculateAge(new DateTime('1880-12-05')),
             ],
             'Bilyana' => [
                 'egn' => '8001010008',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1980-01-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1980-01-01')->age,
+                'dob' => new DateTime('1980-01-01'),
+                'age' => $this->calculateAge(new DateTime('1980-01-01')),
             ],
             'Kalina' => [
                 'egn' => '7501020018',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1975-01-02'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1975-01-02')->age,
+                'dob' => new DateTime('1975-01-02'),
+                'age' => $this->calculateAge(new DateTime('1975-01-02')),
             ],
             'Nedyalko' => [
                 'egn' => '7552010005',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2075-12-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2075-12-01')->age,
+                'dob' => new DateTime('2075-12-01'),
+                'age' => $this->calculateAge(new DateTime('2075-12-01')),
             ],
             'Tsveta' => [
                 'egn' => '7542011030',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2075-02-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2075-02-01')->age,
+                'dob' => new DateTime('2075-02-01'),
+                'age' => $this->calculateAge(new DateTime('2075-02-01')),
             ]
         ];
 
@@ -69,9 +70,10 @@ class BulgariaTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['egn'], 'BG');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -82,13 +84,13 @@ class BulgariaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['egn'], 'BG')
             );
         }
 
         foreach ($this->invalidIds as $egn) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($egn, 'BG')
             );
         }

--- a/tests/Feature/Europe/CroatiaTest.php
+++ b/tests/Feature/Europe/CroatiaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,8 +11,8 @@ use Reducktion\Socrates\Tests\Feature\FeatureTest;
 
 class CroatiaTest extends FeatureTest
 {
-    private $validIds;
     private $people;
+    private $validIds;
     private $invalidIds;
 
     protected function setUp(): void
@@ -30,36 +31,36 @@ class CroatiaTest extends FeatureTest
             'Ivana' => [
                 'jmbg' => '1809988305313',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1988-09-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1988-09-18')->age,
+                'dob' => new DateTime('1988-09-18'),
+                'age' => $this->calculateAge(new DateTime('1988-09-18')),
                 'pob' => 'Osijek, Slavonia region - Croatia'
             ],
             'Ana' => [
                 'jmbg' => '0808928315425',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1928-08-08'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1928-08-08')->age,
+                'dob' => new DateTime('1928-08-08'),
+                'age' => $this->calculateAge(new DateTime('1928-08-08')),
                 'pob' => 'Bjelovar, Virovitica, Koprivnica, Pakrac, Podravina region - Croatia'
             ],
             'Marija' => [
                 'jmbg' => '1106961359224',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1961-06-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1961-06-11')->age,
+                'dob' => new DateTime('1961-06-11'),
+                'age' => $this->calculateAge(new DateTime('1961-06-11')),
                 'pob' => 'Gospić, Lika region - Croatia'
             ],
             'Stjepan' => [
                 'jmbg' => '1105951323209',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1951-05-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1951-05-11')->age,
+                'dob' => new DateTime('1951-05-11'),
+                'age' => $this->calculateAge(new DateTime('1951-05-11')),
                 'pob' => 'Varaždin, Međimurje region - Croatia'
             ],
             'Ivan' => [
                 'jmbg' => '2109971352638',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1971-09-21'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1971-09-21')->age,
+                'dob' => new DateTime('1971-09-21'),
+                'age' => $this->calculateAge(new DateTime('1971-09-21')),
                 'pob' => 'Gospić, Lika region - Croatia'
             ],
         ];
@@ -78,10 +79,11 @@ class CroatiaTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['jmbg'], 'HR');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -96,19 +98,19 @@ class CroatiaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $oib) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($oib, 'HR')
             );
         }
 
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['jmbg'], 'HR')
             );
         }
 
         foreach ($this->invalidIds as $jmbg) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($jmbg, 'HR')
             );
         }

--- a/tests/Feature/Europe/CzechRepublicTest.php
+++ b/tests/Feature/Europe/CzechRepublicTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
@@ -21,32 +22,32 @@ class CzechRepublicTest extends FeatureTest
             'Michal' => [
                 'rc' => '990224/9258',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1999-02-24'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1999-02-24')->age,
+                'dob' => new DateTime('1999-02-24'),
+                'age' => $this->calculateAge(new DateTime('1999-02-24')),
             ],
             'Tereza' => [
                 'rc' => '0157155328',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-07-15'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-07-15')->age,
+                'dob' => new DateTime('2001-07-15'),
+                'age' => $this->calculateAge(new DateTime('2001-07-15')),
             ],
             'Adéla' => [
                 'rc' => '975406/2494',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1997-04-06'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1997-04-06')->age,
+                'dob' => new DateTime('1997-04-06'),
+                'age' => $this->calculateAge(new DateTime('1997-04-06')),
             ],
             'Lucie' => [
                 'rc' => '956022/6027',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1995-10-22'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1995-10-22')->age,
+                'dob' => new DateTime('1995-10-22'),
+                'age' => $this->calculateAge(new DateTime('1995-10-22')),
             ],
             'Petr' => [
                 'rc' => '960326/2955',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1996-03-26'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1996-03-26')->age,
+                'dob' => new DateTime('1996-03-26'),
+                'age' => $this->calculateAge(new DateTime('1996-03-26')),
             ],
         ];
 
@@ -64,9 +65,10 @@ class CzechRepublicTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['rc'], 'CZ');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class CzechRepublicTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['rc'], 'CZ')
             );
         }
 
         foreach ($this->invalidIds as $rc) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($rc, 'CZ')
             );
         }

--- a/tests/Feature/Europe/DenmarkTest.php
+++ b/tests/Feature/Europe/DenmarkTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
@@ -21,32 +22,32 @@ class DenmarkTest extends FeatureTest
             'julius' => [
                 'cpr' => '090792-1395',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1992-07-09'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1992-07-09')->age,
+                'dob' => new DateTime('1992-07-09'),
+                'age' => $this->calculateAge(new DateTime('1992-07-09')),
             ],
             'naja' => [
                 'cpr' => '070593-0600',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1993-05-07'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1993-05-07')->age,
+                'dob' => new DateTime('1993-05-07'),
+                'age' => $this->calculateAge(new DateTime('1993-05-07')),
             ],
             'rolla' => [
                 'cpr' => '150437-3068',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1937-04-15'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1937-04-15')->age,
+                'dob' => new DateTime('1937-04-15'),
+                'age' => $this->calculateAge(new DateTime('1937-04-15')),
             ],
             'thomas' => [
                 'cpr' => '160888-1995',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1988-08-16'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1988-08-16')->age,
+                'dob' => new DateTime('1988-08-16'),
+                'age' => $this->calculateAge(new DateTime('1988-08-16')),
             ],
             'mia' => [
                 'cpr' => '040404-7094',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2004-04-04'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2004-04-04')->age,
+                'dob' => new DateTime('2004-04-04'),
+                'age' => $this->calculateAge(new DateTime('2004-04-04')),
             ],
         ];
 
@@ -64,9 +65,10 @@ class DenmarkTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['cpr'], 'DK');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class DenmarkTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['cpr'], 'DK')
             );
         }
 
         foreach ($this->invalidIds as $cpr) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($cpr, 'DK')
             );
         }

--- a/tests/Feature/Europe/EstoniaTest.php
+++ b/tests/Feature/Europe/EstoniaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
@@ -21,32 +22,32 @@ class EstoniaTest extends FeatureTest
             'Grete' => [
                 'ik' => '48004119745',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1980-04-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1980-04-11')->age,
+                'dob' => new DateTime('1980-04-11'),
+                'age' => $this->calculateAge(new DateTime('1980-04-11')),
             ],
             'Kaarel' => [
                 'ik' => '50108040021',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-08-04'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-08-04')->age,
+                'dob' => new DateTime('2001-08-04'),
+                'age' => $this->calculateAge(new DateTime('2001-08-04')),
             ],
             'Seb' => [
                 'ik' => '36910180118',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1969-10-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1969-10-18')->age,
+                'dob' => new DateTime('1969-10-18'),
+                'age' => $this->calculateAge(new DateTime('1969-10-18')),
             ],
             'Jakob' => [
                 'ik' => '38601230129',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1986-01-23'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1986-01-23')->age,
+                'dob' => new DateTime('1986-01-23'),
+                'age' => $this->calculateAge(new DateTime('1986-01-23')),
             ],
             'Katarina' => [
                 'ik' => '60310275631',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2003-10-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2003-10-27')->age,
+                'dob' => new DateTime('2003-10-27'),
+                'age' => $this->calculateAge(new DateTime('2003-10-27')),
             ],
         ];
 
@@ -63,9 +64,10 @@ class EstoniaTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['ik'], 'EE');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -76,13 +78,13 @@ class EstoniaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['ik'], 'EE')
             );
         }
 
         foreach ($this->invalidIds as $ik) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($ik, 'EE')
             );
         }

--- a/tests/Feature/Europe/FinlandTest.php
+++ b/tests/Feature/Europe/FinlandTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
@@ -21,32 +22,32 @@ class FinlandTest extends FeatureTest
             'senja' => [
                 'hetu' => '040560-600E',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1960-05-04'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1960-05-04')->age
+                'dob' => new DateTime('1960-05-04'),
+                'age' => $this->calculateAge(new DateTime('1960-05-04')),
             ],
             'elias' => [
                 'hetu' => '121093-275N',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1993-10-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1993-10-12')->age
+                'dob' => new DateTime('1993-10-12'),
+                'age' => $this->calculateAge(new DateTime('1993-10-12')),
             ],
             'ida' => [
                 'hetu' => '260555-512H',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1955-05-26'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1955-05-26')->age
+                'dob' => new DateTime('1955-05-26'),
+                'age' => $this->calculateAge(new DateTime('1955-05-26')),
             ],
             'iiro' => [
                 'hetu' => '110416A479W',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2016-04-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2016-04-11')->age
+                'dob' => new DateTime('2016-04-11'),
+                'age' => $this->calculateAge(new DateTime('2016-04-11')),
             ],
             'stig' => [
                 'hetu' => '040403A2676',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2003-04-04'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2003-04-04')->age
+                'dob' => new DateTime('2003-04-04'),
+                'age' => $this->calculateAge(new DateTime('2003-04-04')),
             ]
         ];
 
@@ -64,9 +65,10 @@ class FinlandTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['hetu'], 'FI');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class FinlandTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['hetu'], 'FI')
             );
         }
 
         foreach ($this->invalidIds as $hetu) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($hetu, 'FI')
             );
         }

--- a/tests/Feature/Europe/FranceTest.php
+++ b/tests/Feature/Europe/FranceTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
@@ -21,78 +22,78 @@ class FranceTest extends FeatureTest
             'Annette' => [
                 'insee' => '2820819398814 09',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1982-08'),
-                'age' => Carbon::createFromFormat('Y-m', '1982-08')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1982-08'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1982-08')),
                 'pob' => 'Corrèze'
             ],
             'Lance' => [
                 'insee' => '1350455179061 16',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1935-04'),
-                'age' => Carbon::createFromFormat('Y-m', '1935-04')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1935-04'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1935-04')),
                 'pob' => 'Meuse'
             ],
             'Ancelote' => [
                 'insee' => '2381080214568 11',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1938-10'),
-                'age' => Carbon::createFromFormat('Y-m', '1938-10')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1938-10'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1938-10')),
                 'pob' => 'Somme'
             ],
             'Lothair' => [
                 'insee' => '1880858704571 57',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1988-08'),
-                'age' => Carbon::createFromFormat('Y-m', '1988-08')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1988-08'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1988-08')),
                 'pob' => 'Nièvre'
             ],
             'Millard' => [
                 'insee' => '1030307795669 72',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m', '2003-03'),
-                'age' => Carbon::createFromFormat('Y-m', '2003-03')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '2003-03'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '2003-03')),
                 'pob' => 'Ardèche'
             ],
             'Geoffrey' => [
                 'insee' => '1820897401154 75',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1982-08'),
-                'age' => Carbon::createFromFormat('Y-m', '1982-08')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1982-08'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1982-08')),
                 'pob' => 'Réunion'
             ],
             'Galatee' => [
                 'insee' => '2041098718061 61',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m', '2004-10'),
-                'age' => Carbon::createFromFormat('Y-m', '2004-10')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '2004-10'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '2004-10')),
                 'pob' => 'French Polynesia'
             ],
             'Leal' => [
                 'insee' => '1103442505781 11',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m', '2010-04'),
-                'age' => Carbon::createFromFormat('Y-m', '2010-04')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '2010-04'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '2010-04')),
                 'pob' => 'Loire'
             ],
             'Odelette' => [
                 'insee' => '2115028242370 20',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y', '2011'),
-                'age' => Carbon::createFromFormat('Y', '2011')->age,
+                'dob' => DateTime::createFromFormat('Y', '2011'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y', '2011')),
                 'pob' => 'Eure-et-Loir'
             ],
             'Roch' => [
                 'insee' => '199072A228070 10',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1999-07'),
-                'age' => Carbon::createFromFormat('Y-m', '1999-07')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1999-07'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1999-07')),
                 'pob' => 'Corse-du-Sud'
             ],
             'Nadine' => [
                 'insee' => '257092B844458 87',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m', '1957-09'),
-                'age' => Carbon::createFromFormat('Y-m', '1957-09')->age,
+                'dob' => DateTime::createFromFormat('Y-m', '1957-09'),
+                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1957-09')),
                 'pob' => 'Haute-Corse'
             ]
         ];
@@ -110,10 +111,11 @@ class FranceTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['insee'], 'FR');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -124,13 +126,13 @@ class FranceTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['insee'], 'FR')
             );
         }
 
         foreach ($this->invalidIds as $insee) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($insee, 'FR')
             );
         }

--- a/tests/Feature/Europe/GermanyTest.php
+++ b/tests/Feature/Europe/GermanyTest.php
@@ -10,7 +10,6 @@ use Reducktion\Socrates\Tests\Feature\FeatureTest;
 class GermanyTest extends FeatureTest
 {
     private $validIds;
-
     private $invalidIds;
 
     protected function setUp(): void
@@ -44,13 +43,13 @@ class GermanyTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'DE')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'DE')
             );
         }

--- a/tests/Feature/Europe/GreeceTest.php
+++ b/tests/Feature/Europe/GreeceTest.php
@@ -46,13 +46,13 @@ class GreeceTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'GR')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'GR')
             );
         }

--- a/tests/Feature/Europe/HungaryTest.php
+++ b/tests/Feature/Europe/HungaryTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class HungaryTest extends FeatureTest
             'Aliz' => [
                 'pin' => '2-720216-1673',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1972-02-16'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1972-02-16')->age
+                'dob' => new DateTime('1972-02-16'),
+                'age' => $this->calculateAge(new DateTime('1972-02-16')),
             ],
             'Dora' => [
                 'pin' => '2-690609-5528',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1969-06-09'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1969-06-09')->age
+                'dob' => new DateTime('1969-06-09'),
+                'age' => $this->calculateAge(new DateTime('1969-06-09')),
             ],
             'Jolan' => [
                 'pin' => '2-840320-0414',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1984-03-20'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1984-03-20')->age
+                'dob' => new DateTime('1984-03-20'),
+                'age' => $this->calculateAge(new DateTime('1984-03-20')),
             ],
             'Kapolcs' => [
                 'pin' => '3-101010-5646',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2010-10-10'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2010-10-10')->age
+                'dob' => new DateTime('2010-10-10'),
+                'age' => $this->calculateAge(new DateTime('2010-10-10')),
             ],
             'Vincze' => [
                 'pin' => '3-080321-8523',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2008-03-21'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2008-03-21')->age
+                'dob' => new DateTime('2008-03-21'),
+                'age' => $this->calculateAge(new DateTime('2008-03-21')),
             ],
         ];
 
@@ -57,9 +58,10 @@ class HungaryTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['pin'], 'HU');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -70,13 +72,13 @@ class HungaryTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['pin'], 'HU')
             );
         }
 
         foreach ($this->invalidIds as $pin) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($pin, 'BG')
             );
         }

--- a/tests/Feature/Europe/IcelandTest.php
+++ b/tests/Feature/Europe/IcelandTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Tests\Feature\FeatureTest;
@@ -19,28 +20,28 @@ class IcelandTest extends FeatureTest
         $this->people = [
             'andi' => [
                 'kt' => '0902862349',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1986-02-09'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1986-02-09')->age,
+                'dob' => new DateTime('1986-02-09'),
+                'age' => $this->calculateAge(new DateTime('1986-02-09')),
             ],
             'freyja' => [
                 'kt' => '120174-3399',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1974-01-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1974-01-12')->age,
+                'dob' => new DateTime('1974-01-12'),
+                'age' => $this->calculateAge(new DateTime('1974-01-12')),
             ],
             'nair' => [
                 'kt' => '1808905059',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1990-08-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1990-08-18')->age,
+                'dob' => new DateTime('1990-08-18'),
+                'age' => $this->calculateAge(new DateTime('1990-08-18')),
             ],
             'eva' => [
                 'kt' => '2008108569',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1910-08-20'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1910-08-20')->age,
+                'dob' => new DateTime('1910-08-20'),
+                'age' => $this->calculateAge(new DateTime('1910-08-20')),
             ],
             'hrafn' => [
                 'kt' => '100303-4930',
-                'dob' => Carbon::createFromFormat('Y-m-d', '2003-03-10'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2003-03-10')->age,
+                'dob' => new DateTime('2003-03-10'),
+                'age' => $this->calculateAge(new DateTime('2003-03-10')),
             ],
         ];
 
@@ -58,8 +59,9 @@ class IcelandTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['kt'], 'IS');
 
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -70,13 +72,13 @@ class IcelandTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['kt'], 'IS')
             );
         }
 
         foreach ($this->invalidIds as $kt) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($kt, 'IS')
             );
         }

--- a/tests/Feature/Europe/IrelandTest.php
+++ b/tests/Feature/Europe/IrelandTest.php
@@ -43,13 +43,13 @@ class IrelandTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'IE')
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'IE')
             );
         }

--- a/tests/Feature/Europe/ItalyTest.php
+++ b/tests/Feature/Europe/ItalyTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidIdException;
@@ -22,43 +23,43 @@ class ItalyTest extends FeatureTest
             'matteo moretti' => [
                 'fc' => 'MRTMTT25D09F205Z',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1925-04-09'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1925-04-09')->age,
+                'dob' => new DateTime('1925-04-09'),
+                'age' => $this->calculateAge(new DateTime('1925-04-09')),
                 'pob' => 'MILANO (MI)'
             ],
             'samantha miller' => [
                 'fc' => 'MLLSNT82P65Z404U',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1982-09-25'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1982-09-25')->age,
+                'dob' => new DateTime('1982-09-25'),
+                'age' => $this->calculateAge(new DateTime('1982-09-25')),
                 'pob' => 'STATI UNITI D\'AMERICA'
             ],
             'delmo castiglione' => [
                 'fc' => 'DLMCTG75B07H227Y',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1975-02-07'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1975-02-07')->age,
+                'dob' => new DateTime('1975-02-07'),
+                'age' => $this->calculateAge(new DateTime('1975-02-07')),
                 'pob' => 'REINO (BN)'
             ],
             'elsa barese' => [
                 'fc' => 'BRSLSE08D50H987B',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2008-04-10'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2008-04-10')->age,
+                'dob' => new DateTime('2008-04-10'),
+                'age' => $this->calculateAge(new DateTime('2008-04-10')),
                 'pob' => 'SAN MARTINO ALFIERI (AT)'
             ],
             'dario marcelo' => [
                 'fc' => 'MRCDRA01A13A065E',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-01-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-01-13')->age,
+                'dob' => new DateTime('2001-01-13'),
+                'age' => $this->calculateAge(new DateTime('2001-01-13')),
                 'pob' => 'AFRICO (RC)'
             ],
             'dario marchesani' => [
                 'fc' => 'MRCDRALMAMPALSRE',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-01-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-01-13')->age,
+                'dob' => new DateTime('2001-01-13'),
+                'age' => $this->calculateAge(new DateTime('2001-01-13')),
                 'pob' => 'AFRICO (RC)'
             ]
         ];
@@ -77,10 +78,11 @@ class ItalyTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['fc'], 'IT');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidIdException::class);
@@ -91,13 +93,13 @@ class ItalyTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['fc'], 'IT')
             );
         }
 
         foreach ($this->invalidIds as $fc) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($fc, 'IT')
             );
         }

--- a/tests/Feature/Europe/KosovoTest.php
+++ b/tests/Feature/Europe/KosovoTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,36 +22,36 @@ class KosovoTest extends FeatureTest
             'Fatbard' => [
                 'jmbg' => '1009950933098',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1950-09-10'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1950-09-10')->age,
+                'dob' => new DateTime('1950-09-10'),
+                'age' => $this->calculateAge(new DateTime('1950-09-10')),
                 'pob' => 'Peć region (part of Peć District) - Kosovo'
             ],
             'Erblina' => [
                 'jmbg' => '2601966955857',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1966-01-26'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1966-01-26')->age,
+                'dob' => new DateTime('1966-01-26'),
+                'age' => $this->calculateAge(new DateTime('1966-01-26')),
                 'pob' => 'Prizren region (Prizren District) - Kosovo'
             ],
             'Ajkuna' => [
                 'jmbg' => '2202962926257',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1962-02-22'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1962-02-22')->age,
+                'dob' => new DateTime('1962-02-22'),
+                'age' => $this->calculateAge(new DateTime('1962-02-22')),
                 'pob' => 'Kosovska Mitrovica region (Kosovska Mitrovica District) - Kosovo'
             ],
             'Esad' => [
                 'jmbg' => '1404924982109',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1924-04-14'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1924-04-14')->age,
+                'dob' => new DateTime('1924-04-14'),
+                'age' => $this->calculateAge(new DateTime('1924-04-14')),
                 'pob' => 'Kosovo'
             ],
             'Guzim' => [
                 'jmbg' => '2103921983019',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1921-03-21'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1921-03-21')->age,
+                'dob' => new DateTime('1921-03-21'),
+                'age' => $this->calculateAge(new DateTime('1921-03-21')),
                 'pob' => 'Kosovo'
             ],
         ];
@@ -63,10 +64,11 @@ class KosovoTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['jmbg'], 'XK');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class KosovoTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['jmbg'], 'XK')
             );
         }
 
         foreach ($this->invalidIds as $jmbg) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($jmbg, 'XK')
             );
         }

--- a/tests/Feature/Europe/LatviaTest.php
+++ b/tests/Feature/Europe/LatviaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
@@ -21,28 +22,28 @@ class LatviaTest extends FeatureTest
         $this->supportedExtractionPeople = [
             'Agnese' => [
                 'pk' => '120673-10053',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1973-06-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1973-06-12')->age
+                'dob' => new DateTime('1973-06-12'),
+                'age' => $this->calculateAge(new DateTime('1973-06-12')),
             ],
             'Rainers' => [
                 'pk' => '031098-10386',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1998-10-03'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1998-10-03')->age
+                'dob' => new DateTime('1998-10-03'),
+                'age' => $this->calculateAge(new DateTime('1998-10-03')),
             ],
             'Kin' => [
                 'pk' => '250302-20559',
-                'dob' => Carbon::createFromFormat('Y-m-d', '2002-03-25'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2002-03-25')->age
+                'dob' => new DateTime('2002-03-25'),
+                'age' => $this->calculateAge(new DateTime('2002-03-25')),
             ],
             'Anton' => [
                 'pk' => '300863-10955',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1963-08-30'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1963-08-30')->age
+                'dob' => new DateTime('1963-08-30'),
+                'age' => $this->calculateAge(new DateTime('1963-08-30')),
             ],
             'Karlis' => [
                 'pk' => '171210-20739',
-                'dob' => Carbon::createFromFormat('Y-m-d', '2010-12-17'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2010-12-17')->age
+                'dob' => new DateTime('2010-12-17'),
+                'age' => $this->calculateAge(new DateTime('2010-12-17')),
             ]
         ];
 
@@ -77,8 +78,9 @@ class LatviaTest extends FeatureTest
     {
         foreach ($this->supportedExtractionPeople as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['pk'], 'LV');
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(UnsupportedOperationException::class);
@@ -94,13 +96,13 @@ class LatviaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->supportedExtractionPeople as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['pk'], 'LV')
             );
         }
 
         foreach ($this->invalidIds as $pk) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($pk, 'LV')
             );
         }

--- a/tests/Feature/Europe/LithuaniaTest.php
+++ b/tests/Feature/Europe/LithuaniaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -11,7 +12,6 @@ use Reducktion\Socrates\Tests\Feature\FeatureTest;
 class LithuaniaTest extends FeatureTest
 {
     private $people;
-
     private $invalidIds;
 
     public function setUp(): void
@@ -22,32 +22,32 @@ class LithuaniaTest extends FeatureTest
             'janis' => [
                 'ak' => '38409152012',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1984-09-15'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1984-09-15')->age
+                'dob' => new DateTime('1984-09-15'),
+                'age' => $this->calculateAge(new DateTime('1984-09-15')),
             ],
             'natas' => [
                 'ak' => '31710058023',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1917-10-05'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1917-10-05')->age
+                'dob' => new DateTime('1917-10-05'),
+                'age' => $this->calculateAge(new DateTime('1917-10-05')),
             ],
             'daiva' => [
                 'ak' => '44804129713',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1948-04-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1948-04-12')->age
+                'dob' => new DateTime('1948-04-12'),
+                'age' => $this->calculateAge(new DateTime('1948-04-12')),
             ],
             'geta' => [
                 'ak' => '60607279626',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2006-07-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2006-07-27')->age
+                'dob' => new DateTime('2006-07-27'),
+                'age' => $this->calculateAge(new DateTime('2006-07-27')),
             ],
             'domynikas' => [
                 'ak' => '50508199254',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2005-08-19'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2005-08-19')->age
+                'dob' => new DateTime('2005-08-19'),
+                'age' => $this->calculateAge(new DateTime('2005-08-19')),
             ]
         ];
 
@@ -64,9 +64,10 @@ class LithuaniaTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['ak'], 'LT');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +78,13 @@ class LithuaniaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['ak'], 'LT')
             );
         }
 
         foreach ($this->invalidIds as $ak) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($ak, 'LT')
             );
         }

--- a/tests/Feature/Europe/LuxembourgTest.php
+++ b/tests/Feature/Europe/LuxembourgTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Tests\Feature\FeatureTest;
@@ -19,28 +20,28 @@ class LuxembourgTest extends FeatureTest
         $this->people = [
             'Gabriel' => [
                 'nin' => '1983081246783',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1983-08-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1983-08-12')->age,
+                'dob' => new DateTime('1983-08-12'),
+                'age' => $this->calculateAge(new DateTime('1983-08-12')),
             ],
             'Emma' => [
                 'nin' => '2003042581931',
-                'dob' => Carbon::createFromFormat('Y-m-d', '2003-04-25'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2003-04-25')->age,
+                'dob' => new DateTime('2003-04-25'),
+                'age' => $this->calculateAge(new DateTime('2003-04-25')),
             ],
             'Leo' => [
                 'nin' => '1971110258746',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1971-11-02'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1971-11-02')->age,
+                'dob' => new DateTime('1971-11-02'),
+                'age' => $this->calculateAge(new DateTime('1971-11-02')),
             ],
             'Lara' => [
                 'nin' => '2012051469336',
-                'dob' => Carbon::createFromFormat('Y-m-d', '2012-05-14'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2012-05-14')->age,
+                'dob' => new DateTime('2012-05-14'),
+                'age' => $this->calculateAge(new DateTime('2012-05-14')),
             ],
             'Noah' => [
                 'nin' => '1994092874551',
-                'dob' => Carbon::createFromFormat('Y-m-d', '1994-09-28'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1994-09-28')->age,
+                'dob' => new DateTime('1994-09-28'),
+                'age' => $this->calculateAge(new DateTime('1994-09-28')),
             ],
         ];
 
@@ -57,8 +58,9 @@ class LuxembourgTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['nin'], 'LU');
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -69,13 +71,13 @@ class LuxembourgTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['nin'], 'LU')
             );
         }
 
         foreach ($this->invalidIds as $nin) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($nin, 'LU')
             );
         }

--- a/tests/Feature/Europe/MoldovaTest.php
+++ b/tests/Feature/Europe/MoldovaTest.php
@@ -41,13 +41,13 @@ class MoldovaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'MD')
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'MD')
             );
         }

--- a/tests/Feature/Europe/MontenegroTest.php
+++ b/tests/Feature/Europe/MontenegroTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,37 +22,37 @@ class MontenegroTest extends FeatureTest
             'Crnoje' => [
                 'jmbg' => '2106941231195',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1941-06-21'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1941-06-21')->age,
-                'pob' => 'Budva, Kotor, Tivat - Montenegro'
+                'dob' => new DateTime('1941-06-21'),
+                'age' => $this->calculateAge(new DateTime('1941-06-21')),
+                'pob' => 'Budva, Kotor, Tivat - Montenegro',
             ],
             'Blažo' => [
                 'jmbg' => '1502945264054',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1945-02-15'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1945-02-15')->age,
-                'pob' => 'Nikšić, Plužine, Šavnik - Montenegro'
+                'dob' => new DateTime('1945-02-15'),
+                'age' => $this->calculateAge(new DateTime('1945-02-15')),
+                'pob' => 'Nikšić, Plužine, Šavnik - Montenegro',
             ],
             'Diko' => [
                 'jmbg' => '2007950274591',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1950-07-20'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1950-07-20')->age,
-                'pob' => 'Berane, Rožaje, Plav, Andrijevica - Montenegro'
+                'dob' => new DateTime('1950-07-20'),
+                'age' => $this->calculateAge(new DateTime('1950-07-20')),
+                'pob' => 'Berane, Rožaje, Plav, Andrijevica - Montenegro',
             ],
             'Ema' => [
                 'jmbg' => '1302953216612',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1953-02-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1953-02-13')->age,
-                'pob' => 'Podgorica, Danilovgrad, Kolašin - Montenegro'
+                'dob' => new DateTime('1953-02-13'),
+                'age' => $this->calculateAge(new DateTime('1953-02-13')),
+                'pob' => 'Podgorica, Danilovgrad, Kolašin - Montenegro',
             ],
             'Draginja' => [
                 'jmbg' => '0204942275271',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1942-04-02'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1942-04-02')->age,
-                'pob' => 'Berane, Rožaje, Plav, Andrijevica - Montenegro'
+                'dob' => new DateTime('1942-04-02'),
+                'age' => $this->calculateAge(new DateTime('1942-04-02')),
+                'pob' => 'Berane, Rožaje, Plav, Andrijevica - Montenegro',
             ],
         ];
 
@@ -69,10 +70,11 @@ class MontenegroTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['jmbg'], 'ME');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -83,13 +85,13 @@ class MontenegroTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['jmbg'], 'ME')
             );
         }
 
         foreach ($this->invalidIds as $jmbg) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($jmbg, 'ME')
             );
         }

--- a/tests/Feature/Europe/NetherlandsTest.php
+++ b/tests/Feature/Europe/NetherlandsTest.php
@@ -43,13 +43,13 @@ class NetherlandsTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'NL')
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'NL')
             );
         }

--- a/tests/Feature/Europe/NorthMacedoniaTest.php
+++ b/tests/Feature/Europe/NorthMacedoniaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,37 +22,37 @@ class NorthMacedoniaTest extends FeatureTest
             'Marko' => [
                 'jmbg' => '2408944448442',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1944-08-24'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1944-08-24')->age,
-                'pob' => 'Prilep - North Macedonia'
+                'dob' => new DateTime('1944-08-24'),
+                'age' => $this->calculateAge(new DateTime('1944-08-24')),
+                'pob' => 'Prilep - North Macedonia',
             ],
             'Stefan' => [
                 'jmbg' => '0705957463421',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1957-05-07'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1957-05-07')->age,
-                'pob' => 'Strumica - North Macedonia'
+                'dob' => new DateTime('1957-05-07'),
+                'age' => $this->calculateAge(new DateTime('1957-05-07')),
+                'pob' => 'Strumica - North Macedonia',
             ],
             'Amyntas' => [
                 'jmbg' => '1610936414199',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1936-10-16'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1936-10-16')->age,
-                'pob' => 'Bitola - North Macedonia'
+                'dob' => new DateTime('1936-10-16'),
+                'age' => $this->calculateAge(new DateTime('1936-10-16')),
+                'pob' => 'Bitola - North Macedonia',
             ],
             'Dimitrov' => [
                 'jmbg' => '1207942491481',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1942-07-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1942-07-12')->age,
-                'pob' => 'Štip - North Macedonia'
+                'dob' => new DateTime('1942-07-12'),
+                'age' => $this->calculateAge(new DateTime('1942-07-12')),
+                'pob' => 'Štip - North Macedonia',
             ],
             'Kleitus' => [
                 'jmbg' => '2808928401264',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1928-08-28'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1928-08-28')->age,
-                'pob' => 'North Macedonia'
+                'dob' => new DateTime('1928-08-28'),
+                'age' => $this->calculateAge(new DateTime('1928-08-28')),
+                'pob' => 'North Macedonia',
             ]
         ];
 
@@ -69,10 +70,11 @@ class NorthMacedoniaTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['jmbg'], 'MK');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -83,13 +85,13 @@ class NorthMacedoniaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['jmbg'], 'MK')
             );
         }
 
         foreach ($this->invalidIds as $jmbg) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($jmbg, 'MK')
             );
         }

--- a/tests/Feature/Europe/NorwayTest.php
+++ b/tests/Feature/Europe/NorwayTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class NorwayTest extends FeatureTest
             'kristoffer' => [
                 'fn' => '05080176785',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-08-05'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-08-05')->age,
+                'dob' => new DateTime('2001-08-05'),
+                'age' => $this->calculateAge(new DateTime('2001-08-05')),
             ],
             'astrid' => [
                 'fn' => '20050761232',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2007-05-20'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2007-05-20')->age,
+                'dob' => new DateTime('2007-05-20'),
+                'age' => $this->calculateAge(new DateTime('2007-05-20')),
             ],
             'linn' => [
                 'fn' => '28094949248',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1949-09-28'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1949-09-28')->age,
+                'dob' => new DateTime('1949-09-28'),
+                'age' => $this->calculateAge(new DateTime('1949-09-28')),
             ],
             'terje' => [
                 'fn' => '14019513913',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1995-01-14'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1995-01-14')->age,
+                'dob' => new DateTime('1995-01-14'),
+                'age' => $this->calculateAge(new DateTime('1995-01-14')),
             ],
             'heidi' => [
                 'fn' => '01090749036',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1907-09-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1907-09-01')->age,
+                'dob' => new DateTime('1907-09-01'),
+                'age' => $this->calculateAge(new DateTime('1907-09-01')),
             ],
         ];
 
@@ -64,9 +65,10 @@ class NorwayTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['fn'], 'NO');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class NorwayTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['fn'], 'NO')
             );
         }
 
         foreach ($this->invalidIds as $fn) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($fn, 'NO')
             );
         }

--- a/tests/Feature/Europe/PolandTest.php
+++ b/tests/Feature/Europe/PolandTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class PolandTest extends FeatureTest
             'Alesky' => [
                 'pesel' => '91072592137',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1991-07-25'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1991-07-25')->age,
+                'dob' => new DateTime('1991-07-25'),
+                'age' => $this->calculateAge(new DateTime('1991-07-25')),
             ],
             'Adelajda' => [
                 'pesel' => '02220826789',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2002-02-08'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2002-02-08')->age,
+                'dob' => new DateTime('2002-02-08'),
+                'age' => $this->calculateAge(new DateTime('2002-02-08')),
             ],
             'Izolda' => [
                 'pesel' => '87050832348',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1987-05-08'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1987-05-08')->age,
+                'dob' => new DateTime('1987-05-08'),
+                'age' => $this->calculateAge(new DateTime('1987-05-08')),
             ],
             'Klaudiusz' => [
                 'pesel' => '87012962775',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1987-01-29'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1987-01-29')->age,
+                'dob' => new DateTime('1987-01-29'),
+                'age' => $this->calculateAge(new DateTime('1987-01-29')),
             ],
             'Fryderyk' => [
                 'pesel' => '64032906019',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1964-03-29'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1964-03-29')->age,
+                'dob' => new DateTime('1964-03-29'),
+                'age' => $this->calculateAge(new DateTime('1964-03-29')),
             ],
         ];
 
@@ -63,9 +64,10 @@ class PolandTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['pesel'], 'PL');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -76,13 +78,13 @@ class PolandTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['pesel'], 'PL')
             );
         }
 
         foreach ($this->invalidIds as $pesel) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($pesel, 'PL')
             );
         }

--- a/tests/Feature/Europe/PortugalTest.php
+++ b/tests/Feature/Europe/PortugalTest.php
@@ -43,13 +43,13 @@ class PortugalTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'PT')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'PT')
             );
         }

--- a/tests/Feature/Europe/RomaniaTest.php
+++ b/tests/Feature/Europe/RomaniaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -11,7 +12,6 @@ use Reducktion\Socrates\Tests\Feature\FeatureTest;
 class RomaniaTest extends FeatureTest
 {
     private $people;
-
     private $invalidIds;
 
     public function setUp(): void
@@ -22,36 +22,36 @@ class RomaniaTest extends FeatureTest
             'alexandra' => [
                 'cnp' => '2931213173842',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1993-12-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1993-12-13')->age,
+                'dob' => new DateTime('1993-12-13'),
+                'age' => $this->calculateAge(new DateTime('1993-12-13')),
                 'pob' => 'Galati'
             ],
             'andrei' => [
                 'cnp' => '1941003395747',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1994-10-03'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1994-10-03')->age,
+                'dob' => new DateTime('1994-10-03'),
+                'age' => $this->calculateAge(new DateTime('1994-10-03')),
                 'pob' => 'Vrancea'
             ],
             'elena' => [
                 'cnp' => '2870917211577',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1987-09-17'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1987-09-17')->age,
+                'dob' => new DateTime('1987-09-17'),
+                'age' => $this->calculateAge(new DateTime('1987-09-17')),
                 'pob' => 'Ialomita'
             ],
             'florin' => [
                 'cnp' => '1850327466200',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1985-03-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1985-03-27')->age,
+                'dob' => new DateTime('1985-03-27'),
+                'age' => $this->calculateAge(new DateTime('1985-03-27')),
                 'pob' => 'Bucuresti Sectorul 6'
             ],
             'mihai' => [
                 'cnp' => '5010318045469',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-03-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-03-18')->age,
+                'dob' => new DateTime('2001-03-18'),
+                'age' => $this->calculateAge(new DateTime('2001-03-18')),
                 'pob' => 'Bacau'
             ]
         ];
@@ -69,10 +69,11 @@ class RomaniaTest extends FeatureTest
     {
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['cnp'], 'RO');
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -83,13 +84,13 @@ class RomaniaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['cnp'], 'RO')
             );
         }
 
         foreach ($this->invalidIds as $cnp) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($cnp, 'RO')
             );
         }

--- a/tests/Feature/Europe/SerbiaTest.php
+++ b/tests/Feature/Europe/SerbiaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,37 +22,37 @@ class SerbiaTest extends FeatureTest
             'Nikola' => [
                 'jmbg' => '0101100710006',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2100-01-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2100-01-01')->age,
-                'pob' => 'Belgrade region (City of Belgrade) - Central Serbia'
+                'dob' => new DateTime('2100-01-01'),
+                'age' => $this->calculateAge(new DateTime('2100-01-01')),
+                'pob' => 'Belgrade region (City of Belgrade) - Central Serbia',
             ],
             'Miloje' => [
                 'jmbg' => '0110951074616',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1951-10-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1951-10-01')->age,
-                'pob' => 'foreigners in Serbian province of Vojvodina'
+                'dob' => new DateTime('1951-10-01'),
+                'age' => $this->calculateAge(new DateTime('1951-10-01')),
+                'pob' => 'foreigners in Serbian province of Vojvodina',
             ],
             'Teodora' => [
                 'jmbg' => '2702937737434',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1937-02-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1937-02-27')->age,
-                'pob' => 'Niš region (Nišava District, Pirot District and Toplica District) - Central Serbia'
+                'dob' => new DateTime('1937-02-27'),
+                'age' => $this->calculateAge(new DateTime('1937-02-27')),
+                'pob' => 'Niš region (Nišava District, Pirot District and Toplica District) - Central Serbia',
             ],
             'Jana' => [
                 'jmbg' => '2606936778324',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1936-06-26'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1936-06-26')->age,
-                'pob' => 'Podrinje and Kolubara regions (Mačva District and Kolubara District) - Central Serbia'
+                'dob' => new DateTime('1936-06-26'),
+                'age' => $this->calculateAge(new DateTime('1936-06-26')),
+                'pob' => 'Podrinje and Kolubara regions (Mačva District and Kolubara District) - Central Serbia',
             ],
             'Petra' => [
                 'jmbg' => '1209992745266',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1992-09-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1992-09-12')->age,
-                'pob' => 'Southern Morava region (Jablanica District and Pčinja District) - Central Serbia'
+                'dob' => new DateTime('1992-09-12'),
+                'age' => $this->calculateAge(new DateTime('1992-09-12')),
+                'pob' => 'Southern Morava region (Jablanica District and Pčinja District) - Central Serbia',
             ]
         ];
 
@@ -69,10 +70,11 @@ class SerbiaTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['jmbg'], 'RS');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -83,13 +85,13 @@ class SerbiaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['jmbg'], 'RS')
             );
         }
 
         foreach ($this->invalidIds as $jmbg) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($jmbg, 'RS')
             );
         }

--- a/tests/Feature/Europe/SlovakiaTest.php
+++ b/tests/Feature/Europe/SlovakiaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class SlovakiaTest extends FeatureTest
             'Boris' => [
                 'rc' => '931027/3951',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1993-10-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1993-10-27')->age,
+                'dob' => new DateTime('1993-10-27'),
+                'age' => $this->calculateAge(new DateTime('1993-10-27')),
             ],
             'Miroslav' => [
                 'rc' => '000816/9733',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2000-08-16'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2000-08-16')->age,
+                'dob' => new DateTime('2000-08-16'),
+                'age' => $this->calculateAge(new DateTime('2000-08-16')),
             ],
             'Natalia' => [
                 'rc' => '015612/5552',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-06-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-06-12')->age,
+                'dob' => new DateTime('2001-06-12'),
+                'age' => $this->calculateAge(new DateTime('2001-06-12')),
             ],
             'Victoria' => [
                 'rc' => '935103/6189',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1993-01-03'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1993-01-03')->age,
+                'dob' => new DateTime('1993-01-03'),
+                'age' => $this->calculateAge(new DateTime('1993-01-03')),
             ],
             'Jožko' => [
                 'rc' => '010722/4634',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-07-22'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-07-22')->age,
+                'dob' => new DateTime('2001-07-22'),
+                'age' => $this->calculateAge(new DateTime('2001-07-22')),
             ],
         ];
 
@@ -64,9 +65,10 @@ class SlovakiaTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['rc'], 'SK');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,19 +79,19 @@ class SlovakiaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['rc'], 'SK')
             );
         }
 
         foreach ($this->invalidIds as $rc) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($rc, 'SK')
             );
         }
 
         $this->expectException(InvalidLengthException::class);
 
-        Socrates::validateId('88606/875', 'CZ');
+        Socrates::validateId('88606/875', 'SK');
     }
 }

--- a/tests/Feature/Europe/SloveniaTest.php
+++ b/tests/Feature/Europe/SloveniaTest.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace Reducktion\Socrates\Tests\Feature;
+namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
+use Reducktion\Socrates\Tests\Feature\FeatureTest;
 
 class SloveniaTest extends FeatureTest
 {
@@ -20,37 +22,37 @@ class SloveniaTest extends FeatureTest
             'Luka' => [
                 'emso' => '0101006500006',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2006-01-01'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2006-01-01')->age,
-                'pob' => 'Slovenia'
+                'dob' => new DateTime('2006-01-01'),
+                'age' => $this->calculateAge(new DateTime('2006-01-01')),
+                'pob' => 'Slovenia',
             ],
             'Zoja' => [
                 'emso' => '0310933507830',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1933-10-03'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1933-10-03')->age,
-                'pob' => 'Slovenia'
+                'dob' => new DateTime('1933-10-03'),
+                'age' => $this->calculateAge(new DateTime('1933-10-03')),
+                'pob' => 'Slovenia',
             ],
             'Jaka' => [
                 'emso' => '1408984500257',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1984-08-14'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1984-08-14')->age,
-                'pob' => 'Slovenia'
+                'dob' => new DateTime('1984-08-14'),
+                'age' => $this->calculateAge(new DateTime('1984-08-14')),
+                'pob' => 'Slovenia',
             ],
             'Lana' => [
                 'emso' => '0205962509348',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1962-05-02'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1962-05-02')->age,
-                'pob' => 'Slovenia'
+                'dob' => new DateTime('1962-05-02'),
+                'age' => $this->calculateAge(new DateTime('1962-05-02')),
+                'pob' => 'Slovenia',
             ],
             'Mia' => [
                 'emso' => '1201962509788',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1962-01-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1962-01-12')->age,
-                'pob' => 'Slovenia'
+                'dob' => new DateTime('1962-01-12'),
+                'age' => $this->calculateAge(new DateTime('1962-01-12')),
+                'pob' => 'Slovenia',
             ],
         ];
 
@@ -68,10 +70,11 @@ class SloveniaTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['emso'], 'SI');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
-            $this->assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -82,13 +85,13 @@ class SloveniaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['emso'], 'SI')
             );
         }
 
         foreach ($this->invalidIds as $emso) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($emso, 'SI')
             );
         }

--- a/tests/Feature/Europe/SpainTest.php
+++ b/tests/Feature/Europe/SpainTest.php
@@ -43,13 +43,13 @@ class SpainTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'ES')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'ES')
             );
         }

--- a/tests/Feature/Europe/SwedenTest.php
+++ b/tests/Feature/Europe/SwedenTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class SwedenTest extends FeatureTest
             'alexia' => [
                 'psn' => '550309-6447',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1955-03-09'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1955-03-09')->age,
+                'dob' => new DateTime('1955-03-09'),
+                'age' => $this->calculateAge(new DateTime('1955-03-09')),
             ],
             'otto' => [
                 'psn' => '001020-1895',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2000-10-20'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2000-10-20')->age,
+                'dob' => new DateTime('2000-10-20'),
+                'age' => $this->calculateAge(new DateTime('2000-10-20')),
             ],
             'lowa' => [
                 'psn' => '751208-0222',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1975-12-08'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1975-12-08')->age,
+                'dob' => new DateTime('1975-12-08'),
+                'age' => $this->calculateAge(new DateTime('1975-12-08')),
             ],
             'edward' => [
                 'psn' => '19771211-2775',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1977-12-11'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1977-12-11')->age,
+                'dob' => new DateTime('1977-12-11'),
+                'age' => $this->calculateAge(new DateTime('1977-12-11')),
             ],
             'maia' => [
                 'psn' => '380519-7807',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1938-05-19'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1938-05-19')->age,
+                'dob' => new DateTime('1938-05-19'),
+                'age' => $this->calculateAge(new DateTime('1938-05-19')),
             ],
         ];
 
@@ -64,9 +65,10 @@ class SwedenTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['psn'], 'SE');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class SwedenTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['psn'], 'SE')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'SE')
             );
         }

--- a/tests/Feature/Europe/SwitzerlandTest.php
+++ b/tests/Feature/Europe/SwitzerlandTest.php
@@ -43,13 +43,13 @@ class SwitzerlandTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'CH')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'CH')
             );
         }

--- a/tests/Feature/Europe/TurkeyTest.php
+++ b/tests/Feature/Europe/TurkeyTest.php
@@ -43,13 +43,13 @@ class TurkeyTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'TR')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'TR')
             );
         }

--- a/tests/Feature/Europe/UkraineTest.php
+++ b/tests/Feature/Europe/UkraineTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -21,32 +22,32 @@ class UkraineTest extends FeatureTest
             'petro' => [
                 'id' => '4031090675',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2010-05-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2010-05-13')->age
+                'dob' => new DateTime('2010-05-13'),
+                'age' => $this->calculateAge(new DateTime('2010-05-13')),
             ],
             'vadym' => [
                 'id' => '3292197434',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1990-02-18'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1990-02-18')->age
+                'dob' => new DateTime('1990-02-18'),
+                'age' => $this->calculateAge(new DateTime('1990-02-18')),
             ],
             'veronika' => [
                 'id' => '2023599602',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1955-05-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1955-05-27')->age
+                'dob' => new DateTime('1955-05-27'),
+                'age' => $this->calculateAge(new DateTime('1955-05-27')),
             ],
             'ruslana' => [
                 'id' => '4247134484',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2016-04-12'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2016-04-12')->age
+                'dob' => new DateTime('2016-04-12'),
+                'age' => $this->calculateAge(new DateTime('2016-04-12')),
             ],
             'zoya' => [
                 'id' => '3771509002',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2003-04-05'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2003-04-05')->age
+                'dob' => new DateTime('2003-04-05'),
+                'age' => $this->calculateAge(new DateTime('2003-04-05')),
             ]
         ];
 
@@ -64,9 +65,10 @@ class UkraineTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['id'], 'UA');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -77,13 +79,13 @@ class UkraineTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->people as $person) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($person['id'], 'UA')
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'UA')
             );
         }

--- a/tests/Feature/Europe/UnitedKingdomTest.php
+++ b/tests/Feature/Europe/UnitedKingdomTest.php
@@ -52,13 +52,13 @@ class UnitedKingdomTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'GB')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'GB')
             );
         }

--- a/tests/Feature/FeatureTest.php
+++ b/tests/Feature/FeatureTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature;
 
+use DateTime;
 use Reducktion\Socrates\Tests\TestCase;
 
 abstract class FeatureTest extends TestCase
@@ -9,4 +10,9 @@ abstract class FeatureTest extends TestCase
     abstract public function test_extract_behaviour(): void;
 
     abstract public function test_validation_behaviour(): void;
+
+    public function calculateAge(DateTime $dateOfBirth): int
+    {
+        return (new DateTime())->diff($dateOfBirth)->y;
+    }
 }

--- a/tests/Feature/NorthAmerica/CanadaTest.php
+++ b/tests/Feature/NorthAmerica/CanadaTest.php
@@ -43,13 +43,13 @@ class CanadaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'CA')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'CA')
             );
         }

--- a/tests/Feature/NorthAmerica/MexicoTest.php
+++ b/tests/Feature/NorthAmerica/MexicoTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\NorthAmerica;
 
 use Carbon\Carbon;
+use DateTime;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Laravel\Facades\Socrates;
 use Reducktion\Socrates\Tests\Feature\FeatureTest;
@@ -12,6 +13,7 @@ class MexicoTest extends FeatureTest
 {
     private $validIds;
     private $invalidIds;
+    private $people;
 
     protected function setUp(): void
     {
@@ -21,26 +23,26 @@ class MexicoTest extends FeatureTest
             'juan' => [
                 'curp' => 'MAAR790213HMNRLF03',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1979-2-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1979-2-13')->age,
+                'dob' => new DateTime('1979-2-13'),
+                'age' => $this->calculateAge(new DateTime('1979-2-13')),
             ],
             'letitia' => [
                 'curp' => 'HEGG560427MVZRRL04',
                 'gender' => Gender::FEMALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '1956-4-27'),
-                'age' => Carbon::createFromFormat('Y-m-d', '1956-4-27')->age,
+                'dob' => new DateTime('1956-4-27'),
+                'age' => $this->calculateAge(new DateTime('1956-4-27')),
             ],
             'augustin' => [
                 'curp' => 'BOXW010820HNERXNA1',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2001-8-20'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2001-8-20')->age,
+                'dob' => new DateTime('2001-8-20'),
+                'age' => $this->calculateAge(new DateTime('2001-8-20')),
             ],
             'diego' => [
                 'curp' => 'TUAZ080213HMNRLFA3',
                 'gender' => Gender::MALE,
-                'dob' => Carbon::createFromFormat('Y-m-d', '2008-2-13'),
-                'age' => Carbon::createFromFormat('Y-m-d', '2008-2-13')->age,
+                'dob' => new DateTime('2008-2-13'),
+                'age' => $this->calculateAge(new DateTime('2008-2-13')),
             ],
         ];
 
@@ -81,9 +83,10 @@ class MexicoTest extends FeatureTest
         foreach ($this->people as $person) {
             $citizen = Socrates::getCitizenDataFromId($person['curp'], 'MX');
 
-            $this->assertEquals($person['gender'], $citizen->getGender());
-            $this->assertEquals($person['dob'], $citizen->getDateOfBirth());
-            $this->assertEquals($person['age'], $citizen->getAge());
+            self::assertEquals($person['gender'], $citizen->getGender());
+            self::assertEquals(Carbon::instance($person['dob']), $citizen->getDateOfBirth());
+            self::assertEquals($person['dob'], $citizen->getDateOfBirthNative());
+            self::assertEquals($person['age'], $citizen->getAge());
         }
 
         $this->expectException(InvalidLengthException::class);
@@ -94,13 +97,13 @@ class MexicoTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'MX')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'MX')
             );
         }

--- a/tests/Feature/NorthAmerica/UnitedStatesTest.php
+++ b/tests/Feature/NorthAmerica/UnitedStatesTest.php
@@ -46,13 +46,13 @@ class UnitedStatesTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'US')
             );
         }
 
         foreach ($this->invalidIds as $invalidId) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($invalidId, 'US')
             );
         }

--- a/tests/Feature/SouthAmerica/ArgentinaTest.php
+++ b/tests/Feature/SouthAmerica/ArgentinaTest.php
@@ -49,14 +49,14 @@ class ArgentinaTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'AR'),
                 $id
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'AR')
             );
         }

--- a/tests/Feature/SouthAmerica/BrazilTest.php
+++ b/tests/Feature/SouthAmerica/BrazilTest.php
@@ -66,14 +66,14 @@ class BrazilTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'BR'),
                 $id
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'BR')
             );
         }

--- a/tests/Feature/SouthAmerica/ChileTest.php
+++ b/tests/Feature/SouthAmerica/ChileTest.php
@@ -50,14 +50,14 @@ class ChileTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'CL'),
                 $id
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'CL')
             );
         }

--- a/tests/Feature/SouthAmerica/EcuadorTest.php
+++ b/tests/Feature/SouthAmerica/EcuadorTest.php
@@ -44,14 +44,14 @@ class EcuadorTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'EC'),
                 $id
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'EC')
             );
         }

--- a/tests/Feature/SouthAmerica/PeruTest.php
+++ b/tests/Feature/SouthAmerica/PeruTest.php
@@ -53,14 +53,14 @@ class PeruTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'PE'),
                 $id
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'PE')
             );
         }

--- a/tests/Feature/SouthAmerica/UruguayTest.php
+++ b/tests/Feature/SouthAmerica/UruguayTest.php
@@ -56,14 +56,14 @@ class UruguayTest extends FeatureTest
     public function test_validation_behaviour(): void
     {
         foreach ($this->validIds as $id) {
-            $this->assertTrue(
+            self::assertTrue(
                 Socrates::validateId($id, 'UY'),
                 $id
             );
         }
 
         foreach ($this->invalidIds as $id) {
-            $this->assertFalse(
+            self::assertFalse(
                 Socrates::validateId($id, 'UY')
             );
         }


### PR DESCRIPTION
This PR resolves #106 
As discussed in the issue, we are sunsetting Carbon in an upcoming release of Socrates.
Until then, a temporary `getDateOfBirthNative()` method was added that returns a vanilla PHP `DateTime` instance, and the old `getDateOfBirth()` method has been marked as deprecated.

Additionally, tests were written to make sure we support both `Carbon` and `DateTime` instances. 
I also threw in some minor improvements to some extractors and validators. 